### PR TITLE
Allow for subtitles to be extracted for new media

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>2.1.0.0</Version>
-        <AssemblyVersion>2.1.0.0</AssemblyVersion>
-        <FileVersion>2.1.0.0</FileVersion>
+        <Version>2.0.0.0</Version>
+        <AssemblyVersion>2.0.0.0</AssemblyVersion>
+        <FileVersion>2.0.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>2.0.0.0</Version>
-        <AssemblyVersion>2.0.0.0</AssemblyVersion>
-        <FileVersion>2.0.0.0</FileVersion>
+        <Version>2.1.0.0</Version>
+        <AssemblyVersion>2.1.0.0</AssemblyVersion>
+        <FileVersion>2.1.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Plugins;
 
 namespace Jellyfin.Plugin.SubtitleExtract.Configuration;
 
@@ -24,7 +24,7 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets a value indicating whether the behavior for the metadata provider used on library scan/update.
     /// true - starts extraction and wait for extration to finish.
     /// false - starts extraction and continue.
-    /// default = NonBlocking.
+    /// default = false.
     /// </summary>
     public bool WaitExtraction { get; set; } = false;
 }

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
@@ -7,4 +7,24 @@ namespace Jellyfin.Plugin.SubtitleExtract.Configuration;
 /// </summary>
 public class PluginConfiguration : BasePluginConfiguration
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PluginConfiguration"/> class.
+    /// </summary>
+    public PluginConfiguration()
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not to extract subtitles as part of library scan.
+    /// default = true.
+    /// </summary>
+    public bool ExtractionDuringLibraryScan { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the behavior for the metadata provider used on library scan/update.
+    /// true - starts extraction and wait for extration to finish.
+    /// false - starts extraction and continue.
+    /// default = NonBlocking.
+    /// </summary>
+    public bool WaitExtraction { get; set; } = false;
 }

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
@@ -16,15 +16,7 @@ public class PluginConfiguration : BasePluginConfiguration
 
     /// <summary>
     /// Gets or sets a value indicating whether or not to extract subtitles as part of library scan.
-    /// default = true.
-    /// </summary>
-    public bool ExtractionDuringLibraryScan { get; set; } = true;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the behavior for the metadata provider used on library scan/update.
-    /// true - starts extraction and wait for extration to finish.
-    /// false - starts extraction and continue.
     /// default = false.
     /// </summary>
-    public bool WaitExtraction { get; set; } = false;
+    public bool ExtractionDuringLibraryScan { get; set; } = false;
 }

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
@@ -17,7 +17,7 @@
                             <input is="emby-checkbox" type="checkbox" id="chkEnableDuringScan" />
                             <span>Extract subtitles during library scan</span>
                         </label>
-                        <div class="fieldDescription checkboxFieldDescription">This will make sure subtitles are extracted sooner but will result in longer library scans. Does not disables the scheduled task.</div>
+                        <div class="fieldDescription checkboxFieldDescription">This will make sure subtitles are extracted sooner but will result in longer library scans. Does not disable the scheduled task.</div>
                     </div>
 
                     <br />

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Jellyfin Subtitle Extractor</title>
+</head>
+<body>
+    <div data-role="page" class="page type-interior pluginConfigurationPage subsExtractorConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox,emby-linkbutton">
+
+        <div data-role="content">
+            <div class="content-primary">
+
+                <form class="extractorConfigurationForm">
+                    <br />
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkEnableDuringScan" />
+                            <span>Extract subtitles during library scan</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">This will make sure subtitles are extracted sooner but will result in longer library scans. Does not disables the scheduled task.</div>
+                    </div>
+
+                    <div class="inputContainer">
+                        <select is="emby-select" id="scanBehavior" name="Wait Extration" label="Wait Extration">
+                            <option id="waitScan" value="false">False - Queues extraction and continues library scan.</option>
+                            <option id="notWaitScan" value="true">True - Queues extraction and waits for it to finish.</option>
+                        </select>
+                        <div class="fieldDescription">The default behavior is to not wait, which will add media to the library before extraction finishes.</div>
+                        <div class="fieldDescription">Waiting will ensure all subtitles are extracted before media is added to the library, but will make scans significantly longer.</div>
+                    </div>
+
+                    <br />
+                    <div>
+                        <button is="emby-button" type="submit" class="raised button-submit block emby-button"><span>Save</span></button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <script type="text/javascript">
+
+            (function () {
+
+                var pluginId = "CD893C24-B59E-4060-87B2-184070E1BF68";
+
+                $('.subsExtractorConfigurationPage').on('pageshow', function (event) {
+
+                    var page = this;
+
+                    Dashboard.showLoadingMsg();
+
+                    ApiClient.getPluginConfiguration(pluginId).then(function (config) {
+
+                        page.querySelector('#chkEnableDuringScan').checked = !!config.ExtractionDuringLibraryScan;
+                        page.querySelector('#scanBehavior').value = config.WaitExtraction ? "true" : "false";
+
+                        Dashboard.hideLoadingMsg();
+                    });
+                });
+
+                $('.extractorConfigurationForm').off('submit.plugin').on('submit.plugin', function (e) {
+
+                    Dashboard.showLoadingMsg();
+
+                    var form = this;
+
+                    ApiClient.getPluginConfiguration(pluginId).then(function (config) {
+                        config.ExtractionDuringLibraryScan = form.querySelector('#chkEnableDuringScan').checked;
+                        let WaitExtraction = form.querySelector('#scanBehavior').value == "true";
+                        config.WaitExtraction = WaitExtraction;
+
+                        ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
+                    });
+
+                    return false;
+                });
+
+            })();
+
+        </script>
+    </div>
+</body>
+</html>

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
@@ -20,15 +20,6 @@
                         <div class="fieldDescription checkboxFieldDescription">This will make sure subtitles are extracted sooner but will result in longer library scans. Does not disables the scheduled task.</div>
                     </div>
 
-                    <div class="inputContainer">
-                        <select is="emby-select" id="scanBehavior" name="Wait Extration" label="Wait Extration">
-                            <option id="waitScan" value="false">False - Queues extraction and continues library scan.</option>
-                            <option id="notWaitScan" value="true">True - Queues extraction and waits for it to finish.</option>
-                        </select>
-                        <div class="fieldDescription">The default behavior is to not wait, which will add media to the library before extraction finishes.</div>
-                        <div class="fieldDescription">Waiting will ensure all subtitles are extracted before media is added to the library, but will make scans significantly longer.</div>
-                    </div>
-
                     <br />
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block emby-button"><span>Save</span></button>
@@ -52,7 +43,6 @@
                     ApiClient.getPluginConfiguration(pluginId).then(function (config) {
 
                         page.querySelector('#chkEnableDuringScan').checked = !!config.ExtractionDuringLibraryScan;
-                        page.querySelector('#scanBehavior').value = config.WaitExtraction ? "true" : "false";
 
                         Dashboard.hideLoadingMsg();
                     });
@@ -66,8 +56,6 @@
 
                     ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                         config.ExtractionDuringLibraryScan = form.querySelector('#chkEnableDuringScan').checked;
-                        let WaitExtraction = form.querySelector('#scanBehavior').value == "true";
-                        config.WaitExtraction = WaitExtraction;
 
                         ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                     });

--- a/Jellyfin.Plugin.SubtitleExtract/Jellyfin.Plugin.SubtitleExtract.csproj
+++ b/Jellyfin.Plugin.SubtitleExtract/Jellyfin.Plugin.SubtitleExtract.csproj
@@ -7,7 +7,6 @@
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
-    <NoWarn>CA1819</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,6 +17,10 @@
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Configuration\configPage.html" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
@@ -94,14 +94,7 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
             {
                 _logger.LogInformation("Extracting subtitles for: {Video}", item.Path);
 
-                if (config.WaitExtraction)
-                {
-                    _ = _extractor.Run(item, cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    await _extractor.Run(item, cancellationToken).ConfigureAwait(false);
-                }
+                await _extractor.Run(item, cancellationToken).ConfigureAwait(false);
 
                 _logger.LogInformation("Finished subtitle extraction for: {Video}", item.Path);
             }

--- a/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
@@ -11,7 +11,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.SubtitleExtract.Providers
 {
-    internal class SubsMetadataProvider : ICustomMetadataProvider<Episode>,
+    /// <summary>
+    /// Extracts embedded subtitles while library scanning for immediate access in web player.
+    /// </summary>
+    public class SubsMetadataProvider : ICustomMetadataProvider<Episode>,
         ICustomMetadataProvider<Movie>,
         ICustomMetadataProvider<Video>,
         IHasItemChangeMonitor,
@@ -22,6 +25,12 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger<SubsMetadataProvider> _logger;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubsMetadataProvider"/> class.
+        /// </summary>
+        /// <param name="subtitleEncoder">Instance of the <see cref="ISubtitleEncoder"/> interface.</param>
+        /// <param name="loggerFactory">Instance of the <see cref="ILoggerFactory"/> interface.</param>
+        /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
         public SubsMetadataProvider(
             ISubtitleEncoder subtitleEncoder,
             ILoggerFactory loggerFactory,
@@ -40,6 +49,7 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
         /// </summary>
         public int Order => 1000;
 
+        /// <inheritdoc/>
         public bool HasChanged(BaseItem item, IDirectoryService directoryService)
         {
             if (item.IsFileProtocol)
@@ -54,16 +64,19 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
             return false;
         }
 
+        /// <inheritdoc/>
         public Task<ItemUpdateType> FetchAsync(Episode item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             return FetchSubtitles(item, cancellationToken);
         }
 
+        /// <inheritdoc/>
         public Task<ItemUpdateType> FetchAsync(Movie item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             return FetchSubtitles(item, cancellationToken);
         }
 
+        /// <inheritdoc/>
         public Task<ItemUpdateType> FetchAsync(Video item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
             return FetchSubtitles(item, cancellationToken);

--- a/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
@@ -44,7 +44,7 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
         }
 
         /// <inheritdoc />
-        public string Name => "Jellyfin Subtitle Extractor";
+        public string Name => SubtitleExtractPlugin.Current.Name;
 
         /// <summary>
         /// Gets the order in which the provider should be called. (Core provider is = 100).

--- a/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
@@ -30,7 +30,6 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
             _subtitleEncoder = subtitleEncoder;
             _logger = logger;
             _loggerFactory = loggerFactory;
-            _logger.LogInformation("Provider instanciado");
         }
 
         /// <inheritdoc />
@@ -39,11 +38,10 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
         /// <summary>
         /// Gets the order in which the provider should be called. (Core provider is = 100).
         /// </summary>
-        public int Order => 900;
+        public int Order => 1000;
 
         public bool HasChanged(BaseItem item, IDirectoryService directoryService)
         {
-            _logger.LogInformation("Provider comprobando cambios");
             if (item.IsFileProtocol)
             {
                 var file = directoryService.GetFile(item.Path);
@@ -58,33 +56,27 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
 
         public Task<ItemUpdateType> FetchAsync(Episode item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Provider recibe episodio");
             return FetchSubtitles(item, cancellationToken);
         }
 
         public Task<ItemUpdateType> FetchAsync(Movie item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Provider recibe peli");
             return FetchSubtitles(item, cancellationToken);
         }
 
         public Task<ItemUpdateType> FetchAsync(Video item, MetadataRefreshOptions options, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Provider recibe video");
             return FetchSubtitles(item, cancellationToken);
         }
 
         private async Task<ItemUpdateType> FetchSubtitles(BaseItem item, CancellationToken cancellationToken)
         {
-            _logger.LogInformation("Provider empieza a trabajar");
             var config = SubtitleExtractPlugin.Current!.Configuration;
-
-            _logger.LogInformation("Config cargada: {Extract} y {Wait}", config.ExtractionDuringLibraryScan, config.WaitExtraction);
 
             if (config.ExtractionDuringLibraryScan)
             {
                 var extractor = new SubtitlesExtractor(_loggerFactory.CreateLogger<SubtitlesExtractor>(), _subtitleEncoder);
-                _logger.LogInformation("Provider extrayendo para {Video}", item);
+                _logger.LogInformation("Extracting subtitles for: {Video}", item);
 
                 if (config.WaitExtraction)
                 {
@@ -94,6 +86,8 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
                 {
                     await extractor.Run(item, cancellationToken).ConfigureAwait(false);
                 }
+
+                _logger.LogInformation("Finished subtitle extraction for: {Video}", item);
             }
 
             return ItemUpdateType.None;

--- a/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
@@ -22,7 +22,6 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
         IForcedProvider
     {
         private readonly ISubtitleEncoder _subtitleEncoder;
-        private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger<SubsMetadataProvider> _logger;
 
         private readonly SubtitlesExtractor _extractor;
@@ -40,9 +39,8 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
         {
             _subtitleEncoder = subtitleEncoder;
             _logger = logger;
-            _loggerFactory = loggerFactory;
 
-            _extractor = new SubtitlesExtractor(_loggerFactory.CreateLogger<SubtitlesExtractor>(), _subtitleEncoder);
+            _extractor = new SubtitlesExtractor(loggerFactory.CreateLogger<SubtitlesExtractor>(), _subtitleEncoder);
         }
 
         /// <inheritdoc />

--- a/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
@@ -1,0 +1,102 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SubtitleExtract.Tools;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Providers;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SubtitleExtract.Providers
+{
+    internal class SubsMetadataProvider : ICustomMetadataProvider<Episode>,
+        ICustomMetadataProvider<Movie>,
+        ICustomMetadataProvider<Video>,
+        IHasItemChangeMonitor,
+        IHasOrder,
+        IForcedProvider
+    {
+        private readonly ISubtitleEncoder _subtitleEncoder;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly ILogger<SubsMetadataProvider> _logger;
+
+        public SubsMetadataProvider(
+            ISubtitleEncoder subtitleEncoder,
+            ILoggerFactory loggerFactory,
+            ILogger<SubsMetadataProvider> logger)
+        {
+            _subtitleEncoder = subtitleEncoder;
+            _logger = logger;
+            _loggerFactory = loggerFactory;
+            _logger.LogInformation("Provider instanciado");
+        }
+
+        /// <inheritdoc />
+        public string Name => "Jellyfin Subtitle Extractor";
+
+        /// <summary>
+        /// Gets the order in which the provider should be called. (Core provider is = 100).
+        /// </summary>
+        public int Order => 900;
+
+        public bool HasChanged(BaseItem item, IDirectoryService directoryService)
+        {
+            _logger.LogInformation("Provider comprobando cambios");
+            if (item.IsFileProtocol)
+            {
+                var file = directoryService.GetFile(item.Path);
+                if (file != null && item.DateModified != file.LastWriteTimeUtc)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public Task<ItemUpdateType> FetchAsync(Episode item, MetadataRefreshOptions options, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Provider recibe episodio");
+            return FetchSubtitles(item, cancellationToken);
+        }
+
+        public Task<ItemUpdateType> FetchAsync(Movie item, MetadataRefreshOptions options, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Provider recibe peli");
+            return FetchSubtitles(item, cancellationToken);
+        }
+
+        public Task<ItemUpdateType> FetchAsync(Video item, MetadataRefreshOptions options, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Provider recibe video");
+            return FetchSubtitles(item, cancellationToken);
+        }
+
+        private async Task<ItemUpdateType> FetchSubtitles(BaseItem item, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Provider empieza a trabajar");
+            var config = SubtitleExtractPlugin.Current!.Configuration;
+
+            _logger.LogInformation("Config cargada: {Extract} y {Wait}", config.ExtractionDuringLibraryScan, config.WaitExtraction);
+
+            if (config.ExtractionDuringLibraryScan)
+            {
+                var extractor = new SubtitlesExtractor(_loggerFactory.CreateLogger<SubtitlesExtractor>(), _subtitleEncoder);
+                _logger.LogInformation("Provider extrayendo para {Video}", item);
+
+                if (config.WaitExtraction)
+                {
+                    _ = extractor.Run(item, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await extractor.Run(item, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            return ItemUpdateType.None;
+        }
+    }
+}

--- a/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Providers/SubsMetadataProvider.cs
@@ -25,6 +25,8 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger<SubsMetadataProvider> _logger;
 
+        private readonly SubtitlesExtractor _extractor;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SubsMetadataProvider"/> class.
         /// </summary>
@@ -39,6 +41,8 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
             _subtitleEncoder = subtitleEncoder;
             _logger = logger;
             _loggerFactory = loggerFactory;
+
+            _extractor = new SubtitlesExtractor(_loggerFactory.CreateLogger<SubtitlesExtractor>(), _subtitleEncoder);
         }
 
         /// <inheritdoc />
@@ -88,19 +92,18 @@ namespace Jellyfin.Plugin.SubtitleExtract.Providers
 
             if (config.ExtractionDuringLibraryScan)
             {
-                var extractor = new SubtitlesExtractor(_loggerFactory.CreateLogger<SubtitlesExtractor>(), _subtitleEncoder);
-                _logger.LogInformation("Extracting subtitles for: {Video}", item);
+                _logger.LogInformation("Extracting subtitles for: {Video}", item.Path);
 
                 if (config.WaitExtraction)
                 {
-                    _ = extractor.Run(item, cancellationToken).ConfigureAwait(false);
+                    _ = _extractor.Run(item, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
-                    await extractor.Run(item, cancellationToken).ConfigureAwait(false);
+                    await _extractor.Run(item, cancellationToken).ConfigureAwait(false);
                 }
 
-                _logger.LogInformation("Finished subtitle extraction for: {Video}", item);
+                _logger.LogInformation("Finished subtitle extraction for: {Video}", item.Path);
             }
 
             return ItemUpdateType.None;

--- a/Jellyfin.Plugin.SubtitleExtract/SubtitleExtractPlugin.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/SubtitleExtractPlugin.cs
@@ -28,7 +28,7 @@ public class SubtitleExtractPlugin : BasePlugin<PluginConfiguration>, IHasWebPag
     public override string Name => "Subtitle Extract";
 
     /// <inheritdoc />
-    public override Guid Id => Guid.Parse("CD893C24-B59E-4060-87B2-184070E1BF68");
+    public override Guid Id => new("CD893C24-B59E-4060-87B2-184070E1BF68");
 
     /// <inheritdoc />
     public override string Description => "Extracts embedded subtitles";
@@ -36,7 +36,7 @@ public class SubtitleExtractPlugin : BasePlugin<PluginConfiguration>, IHasWebPag
     /// <summary>
     /// Gets the current plugin instance.
     /// </summary>
-    public static SubtitleExtractPlugin? Current { get; private set; }
+    public static SubtitleExtractPlugin Current { get; private set; } = null!;
 
     /// <inheritdoc />
     public IEnumerable<PluginPageInfo> GetPages()

--- a/Jellyfin.Plugin.SubtitleExtract/SubtitleExtractPlugin.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/SubtitleExtractPlugin.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using Jellyfin.Plugin.SubtitleExtract.Configuration;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
+using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
 
 namespace Jellyfin.Plugin.SubtitleExtract;
@@ -9,7 +11,7 @@ namespace Jellyfin.Plugin.SubtitleExtract;
 /// <summary>
 /// Plugin entrypoint.
 /// </summary>
-public class SubtitleExtractPlugin : BasePlugin<PluginConfiguration>
+public class SubtitleExtractPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SubtitleExtractPlugin"/> class.
@@ -26,7 +28,7 @@ public class SubtitleExtractPlugin : BasePlugin<PluginConfiguration>
     public override string Name => "Subtitle Extract";
 
     /// <inheritdoc />
-    public override Guid Id => new("CD893C24-B59E-4060-87B2-184070E1BF68");
+    public override Guid Id => Guid.Parse("CD893C24-B59E-4060-87B2-184070E1BF68");
 
     /// <inheritdoc />
     public override string Description => "Extracts embedded subtitles";
@@ -34,5 +36,18 @@ public class SubtitleExtractPlugin : BasePlugin<PluginConfiguration>
     /// <summary>
     /// Gets the current plugin instance.
     /// </summary>
-    public static SubtitleExtractPlugin Current { get; private set; } = null!;
+    public static SubtitleExtractPlugin? Current { get; private set; }
+
+    /// <inheritdoc />
+    public IEnumerable<PluginPageInfo> GetPages()
+    {
+        return new[]
+        {
+            new PluginPageInfo
+            {
+                Name = "Jellyfin subtitle extrator",
+                EmbeddedResourcePath = GetType().Namespace + ".Configuration.configPage.html"
+            }
+        };
+    }
 }

--- a/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
@@ -1,18 +1,16 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
-using Jellyfin.Extensions;
+using Jellyfin.Plugin.SubtitleExtract.Tools;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
-using MediaBrowser.Model.MediaInfo;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -28,10 +26,9 @@ public class ExtractSubtitlesTask : IScheduledTask
     private readonly ILibraryManager _libraryManager;
     private readonly ISubtitleEncoder _subtitleEncoder;
     private readonly ILocalizationManager _localization;
-    private readonly ILogger<ExtractSubtitlesTask> _logger;
+    private readonly ILoggerFactory _loggerFactory;
 
     private static readonly BaseItemKind[] _itemTypes = { BaseItemKind.Episode, BaseItemKind.Movie };
-    private static readonly string[] _supportedFormats = { SubtitleFormat.SRT, SubtitleFormat.ASS, SubtitleFormat.SSA };
     private static readonly string[] _mediaTypes = { MediaType.Video };
     private static readonly SourceType[] _sourceTypes = { SourceType.Library };
     private static readonly DtoOptions _dtoOptions = new(false);
@@ -42,27 +39,27 @@ public class ExtractSubtitlesTask : IScheduledTask
     /// <param name="libraryManager">Instance of <see cref="ILibraryManager"/> interface.</param>
     /// /// <param name="subtitleEncoder">Instance of <see cref="ISubtitleEncoder"/> interface.</param>
     /// <param name="localization">Instance of <see cref="ILocalizationManager"/> interface.</param>
-    /// <param name="logger">Instance of the <see cref="ILogger{ExtractSubtitlesTask}"/> interface.</param>
+    /// <param name="loggerFactory">Instance of the <see cref="ILoggerFactory"/> interface.</param>
     public ExtractSubtitlesTask(
         ILibraryManager libraryManager,
         ISubtitleEncoder subtitleEncoder,
         ILocalizationManager localization,
-        ILogger<ExtractSubtitlesTask> logger)
+        ILoggerFactory loggerFactory)
     {
         _libraryManager = libraryManager;
         _subtitleEncoder = subtitleEncoder;
         _localization = localization;
-        _logger = logger;
+        _loggerFactory = loggerFactory;
     }
 
     /// <inheritdoc />
     public string Key => "ExtractSubtitles";
 
     /// <inheritdoc />
-    public string Name => SubtitleExtractPlugin.Current.Name;
+    public string Name => SubtitleExtractPlugin.Current!.Name;
 
     /// <inheritdoc />
-    public string Description => SubtitleExtractPlugin.Current.Name;
+    public string Description => SubtitleExtractPlugin.Current!.Description;
 
     /// <inheritdoc />
     public string Category => _localization.GetLocalizedString("TasksLibraryCategory");
@@ -90,6 +87,8 @@ public class ExtractSubtitlesTask : IScheduledTask
         var startIndex = 0;
         var completedVideos = 0;
 
+        var extractor = new SubtitlesExtractor(_loggerFactory.CreateLogger<SubtitlesExtractor>(), _subtitleEncoder);
+
         while (startIndex < numberOfVideos)
         {
             query.StartIndex = startIndex;
@@ -99,43 +98,7 @@ public class ExtractSubtitlesTask : IScheduledTask
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                try
-                {
-                    var mediaSourceId = video.Id.ToString("N", CultureInfo.InvariantCulture);
-                    var streams = video.GetMediaStreams()
-                        .Where(stream => stream.IsTextSubtitleStream
-                                         && stream.SupportsExternalStream
-                                         && !stream.IsExternal);
-                    foreach (var stream in streams)
-                    {
-                        var index = stream.Index;
-                        var format = stream.Codec;
-
-                        try
-                        {
-                            // SubtitleEncoder has readers only for these formats, everything else converted to SRT.
-                            if (!_supportedFormats.Contains(format, StringComparison.OrdinalIgnoreCase))
-                            {
-                                format = SubtitleFormat.SRT;
-                            }
-
-                            await _subtitleEncoder.GetSubtitles(video, mediaSourceId, index, format, 0, 0, false, cancellationToken).ConfigureAwait(false);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(
-                                ex,
-                                "Unable to extract subtitle File:{File}\tStreamIndex:{Index}\tCodec:{Codec}",
-                                video.Path,
-                                index,
-                                format);
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Unable to get streams for File:{File}", video.Path);
-                }
+                await extractor.Run(video, cancellationToken).ConfigureAwait(false);
 
                 completedVideos++;
                 progress.Report(100d * completedVideos / numberOfVideos);

--- a/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
@@ -26,7 +26,6 @@ public class ExtractSubtitlesTask : IScheduledTask
     private readonly ILibraryManager _libraryManager;
     private readonly ISubtitleEncoder _subtitleEncoder;
     private readonly ILocalizationManager _localization;
-    private readonly ILoggerFactory _loggerFactory;
 
     private static readonly BaseItemKind[] _itemTypes = { BaseItemKind.Episode, BaseItemKind.Movie };
     private static readonly string[] _mediaTypes = { MediaType.Video };
@@ -51,8 +50,7 @@ public class ExtractSubtitlesTask : IScheduledTask
         _libraryManager = libraryManager;
         _subtitleEncoder = subtitleEncoder;
         _localization = localization;
-        _loggerFactory = loggerFactory;
-        _extractor = new SubtitlesExtractor(_loggerFactory.CreateLogger<SubtitlesExtractor>(), _subtitleEncoder);
+        _extractor = new SubtitlesExtractor(loggerFactory.CreateLogger<SubtitlesExtractor>(), _subtitleEncoder);
     }
 
     /// <inheritdoc />

--- a/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
@@ -33,6 +33,8 @@ public class ExtractSubtitlesTask : IScheduledTask
     private static readonly SourceType[] _sourceTypes = { SourceType.Library };
     private static readonly DtoOptions _dtoOptions = new(false);
 
+    private readonly SubtitlesExtractor _extractor;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ExtractSubtitlesTask" /> class.
     /// </summary>
@@ -50,6 +52,7 @@ public class ExtractSubtitlesTask : IScheduledTask
         _subtitleEncoder = subtitleEncoder;
         _localization = localization;
         _loggerFactory = loggerFactory;
+        _extractor = new SubtitlesExtractor(_loggerFactory.CreateLogger<SubtitlesExtractor>(), _subtitleEncoder);
     }
 
     /// <inheritdoc />
@@ -87,8 +90,6 @@ public class ExtractSubtitlesTask : IScheduledTask
         var startIndex = 0;
         var completedVideos = 0;
 
-        var extractor = new SubtitlesExtractor(_loggerFactory.CreateLogger<SubtitlesExtractor>(), _subtitleEncoder);
-
         while (startIndex < numberOfVideos)
         {
             query.StartIndex = startIndex;
@@ -98,7 +99,7 @@ public class ExtractSubtitlesTask : IScheduledTask
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                await extractor.Run(video, cancellationToken).ConfigureAwait(false);
+                await _extractor.Run(video, cancellationToken).ConfigureAwait(false);
 
                 completedVideos++;
                 progress.Report(100d * completedVideos / numberOfVideos);

--- a/Jellyfin.Plugin.SubtitleExtract/Tools/SubtitlesExtractor.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tools/SubtitlesExtractor.cs
@@ -24,8 +24,8 @@ namespace Jellyfin.Plugin.SubtitleExtract.Tools
         /// <summary>
         /// Initializes a new instance of the <see cref="SubtitlesExtractor"/> class.
         /// </summary>
-        /// <param name="logger">Logger class.</param>
-        /// <param name="subtitleEncoder">Subtitles encoder..</param>
+        /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
+        /// <param name="subtitleEncoder">Instance of the <see cref="ISubtitleEncoder"/> interface.</param>
         public SubtitlesExtractor(
             ILogger<SubtitlesExtractor> logger,
             ISubtitleEncoder subtitleEncoder)

--- a/Jellyfin.Plugin.SubtitleExtract/Tools/SubtitlesExtractor.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tools/SubtitlesExtractor.cs
@@ -62,7 +62,7 @@ namespace Jellyfin.Plugin.SubtitleExtract.Tools
                             format = SubtitleFormat.SRT;
                         }
 
-                        _logger.LogInformation("Extracting subtitle stream {Index} from {Video} as {Format}", index, video, format);
+                        _logger.LogInformation("Extracting subtitle stream {Index} from {Video} as {Format}", index, video.Path, format);
 
                         await _subtitleEncoder.GetSubtitles(video, mediaSourceId, index, format, 0, 0, false, cancellationToken).ConfigureAwait(false);
                     }

--- a/Jellyfin.Plugin.SubtitleExtract/Tools/SubtitlesExtractor.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tools/SubtitlesExtractor.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Extensions;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Model.MediaInfo;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SubtitleExtract.Tools
+{
+    /// <summary>
+    /// Helper class to extract subtitles for immediate access in web player.
+    /// </summary>
+    public class SubtitlesExtractor
+    {
+        private readonly ISubtitleEncoder _subtitleEncoder;
+        private readonly ILogger<SubtitlesExtractor> _logger;
+
+        private static readonly string[] _supportedFormats = { SubtitleFormat.SRT, SubtitleFormat.ASS, SubtitleFormat.SSA };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubtitlesExtractor"/> class.
+        /// </summary>
+        /// <param name="logger">Logger class.</param>
+        /// <param name="subtitleEncoder">Subtitles encoder..</param>
+        public SubtitlesExtractor(
+            ILogger<SubtitlesExtractor> logger,
+            ISubtitleEncoder subtitleEncoder)
+        {
+            _subtitleEncoder = subtitleEncoder;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Extract subtitles from video files.
+        /// </summary>
+        /// <param name="video">The video to extract subtitles from.</param>
+        /// <param name="cancellationToken">Token to cancel async process.</param>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        public async Task Run(BaseItem video, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var mediaSourceId = video.Id.ToString("N", CultureInfo.InvariantCulture);
+                var streams = video.GetMediaStreams()
+                    .Where(stream => stream.IsTextSubtitleStream
+                                     && stream.SupportsExternalStream
+                                     && !stream.IsExternal);
+                foreach (var stream in streams)
+                {
+                    var index = stream.Index;
+                    var format = stream.Codec;
+
+                    try
+                    {
+                        // SubtitleEncoder has readers only for these formats, everything else converted to SRT.
+                        if (!_supportedFormats.Contains(format, StringComparison.OrdinalIgnoreCase))
+                        {
+                            format = SubtitleFormat.SRT;
+                        }
+
+                        _logger.LogInformation("Extracting subtitle stream {Index} from {Video} as {Format}", index, video, format);
+
+                        await _subtitleEncoder.GetSubtitles(video, mediaSourceId, index, format, 0, 0, false, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(
+                            ex,
+                            "Unable to extract subtitle File:{File}\tStreamIndex:{Index}\tCodec:{Codec}",
+                            video.Path,
+                            index,
+                            format);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Unable to get streams for File:{File}", video.Path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implementing this would allow subtitles to always be external, wich would make the need of transcoding due to slow loading subtitles gone even if the video has just been added.

Its implemented using  a custom metadata provider that calls for the same code as the task did.

Task works as always, but the provider doesnt seem to be loading. its my frist time touching jellyfin, so maybe registering the provider is needed, but after looking for a lot of examples can't find anything related.

It should work after finding why it doesn't load, at leats it doesn't on my test server while doing library scans as it should.