### PR TITLE
Add libraries selector

### DIFF
--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/CheckboxItem.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/CheckboxItem.cs
@@ -1,0 +1,35 @@
+﻿namespace Jellyfin.Plugin.SubtitleExtract.Configuration;
+
+/// <summary>
+/// Container for the checkbox model.
+/// </summary>
+public class CheckboxItem
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CheckboxItem"/> class.
+    /// </summary>
+    public CheckboxItem()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CheckboxItem"/> class.
+    /// </summary>
+    /// <param name="value">The checkbox value.</param>
+    /// <param name="text">The checkbox text.</param>
+    public CheckboxItem(string value, string text)
+    {
+        Value = value;
+        Text = text;
+    }
+
+    /// <summary>
+    /// Gets or sets the checkbox value.
+    /// </summary>
+    public string? Value { get; set; }
+
+    /// <summary>
+    /// Gets or sets the checkbox text.
+    /// </summary>
+    public string? Text { get; set; }
+}

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
@@ -19,4 +19,19 @@ public class PluginConfiguration : BasePluginConfiguration
     /// default = false.
     /// </summary>
     public bool ExtractionDuringLibraryScan { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the list of selected libraries to extract subtitles from (empty means all).
+    /// </summary>
+    public string SelectedSubtitlesLibraries { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the list of selected libraries to extract attachments from (empty means all).
+    /// </summary>
+    public string SelectedAttachmentsLibraries { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the list of codecs to look for when extracting subtitles (empty means all).
+    /// </summary>
+    public string IncludedCodecs { get; set; } = string.Empty;
 }

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
@@ -34,4 +34,9 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the list of codecs to look for when extracting subtitles (empty means all).
     /// </summary>
     public string IncludedCodecs { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the list of codecs to exclude from subtitles extraction (empty means none).
+    /// </summary>
+    public string ExcludedCodecs { get; set; } = string.Empty;
 }

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
@@ -60,4 +60,19 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Gets or sets the list of codecs to include when extracting subtitle from a media.
     /// </summary>
     public string SelectedCodecs { get; set; } = string.Join(", ", _allSubtitleCodecs);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether advanced codec selection mode is enabled.
+    /// </summary>
+    public bool IsAdvancedMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether advanced codec selection mode is enabled.
+    /// </summary>
+    public bool IncludeTextSubtitles { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether advanced codec selection mode is enabled.
+    /// </summary>
+    public bool IncludeGraphicalSubtitles { get; set; } = true;
 }

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using MediaBrowser.Model.Plugins;
 
 namespace Jellyfin.Plugin.SubtitleExtract.Configuration;
@@ -7,6 +8,26 @@ namespace Jellyfin.Plugin.SubtitleExtract.Configuration;
 /// </summary>
 public class PluginConfiguration : BasePluginConfiguration
 {
+    private static readonly List<string> _allSubtitleCodecs =
+    [
+        "ass - ASS (Advanced SSA) subtitle (.ass & .ssa files - often found on anime)",
+        "DVDSUB - DVD subtitles", "subrip - SubRip subtitle (.srt files - most common type of subtitles)",
+        "PGSSUB - HDMV Presentation Graphic Stream subtitles (often found on Blu-ray)",
+        "DVBSUB - DVB subtitles", "eia_608 - EIA-608 closed captions",
+        "jacosub - JACOsub subtitle",
+        "microdvd - MicroDVD subtitle", "mov_text - MOV text",
+        "mpl2 - MPL2 subtitle",
+        "pjs - PJS (Phoenix Japanimation Society) subtitle",
+        "realtext - RealText subtitle",
+        "sami - SAMI subtitle", "stl - Spruce subtitle format",
+        "subviewer - SubViewer subtitle",
+        "subviewer1 - SubViewer v1 subtitle",
+        "text - raw UTF-8 text",
+        "vplayer - VPlayer subtitle",
+        "webvtt - WebVTT subtitle",
+        "xsub - XSUB"
+    ];
+
     /// <summary>
     /// Initializes a new instance of the <see cref="PluginConfiguration"/> class.
     /// </summary>
@@ -31,12 +52,12 @@ public class PluginConfiguration : BasePluginConfiguration
     public string SelectedAttachmentsLibraries { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the list of codecs to look for when extracting subtitles (empty means all).
+    /// Gets all available subtitle codecs.
     /// </summary>
-    public string IncludedCodecs { get; set; } = string.Empty;
+    public string AllSubtitleCodecs => string.Join("#", _allSubtitleCodecs);
 
     /// <summary>
-    /// Gets or sets the list of codecs to exclude from subtitles extraction (empty means none).
+    /// Gets or sets the list of codecs to include when extracting subtitle from a media.
     /// </summary>
-    public string ExcludedCodecs { get; set; } = string.Empty;
+    public string SelectedCodecs { get; set; } = string.Join(", ", _allSubtitleCodecs);
 }

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
@@ -1,4 +1,6 @@
-using System.Collections.Generic;
+#pragma warning disable CA1819 // Properties should not return arrays
+
+using System.Linq;
 using MediaBrowser.Model.Plugins;
 
 namespace Jellyfin.Plugin.SubtitleExtract.Configuration;
@@ -8,24 +10,28 @@ namespace Jellyfin.Plugin.SubtitleExtract.Configuration;
 /// </summary>
 public class PluginConfiguration : BasePluginConfiguration
 {
-    private static readonly List<string> _allSubtitleCodecs =
+    private static readonly CheckboxItem[] _allSubtitleCodecs =
     [
-        "ass - ASS (Advanced SSA) subtitle (.ass & .ssa files - often found on anime)",
-        "DVDSUB - DVD subtitles", "subrip - SubRip subtitle (.srt files - most common type of subtitles)",
-        "PGSSUB - HDMV Presentation Graphic Stream subtitles (often found on Blu-ray)",
-        "DVBSUB - DVB subtitles", "eia_608 - EIA-608 closed captions",
-        "jacosub - JACOsub subtitle",
-        "microdvd - MicroDVD subtitle", "mov_text - MOV text",
-        "mpl2 - MPL2 subtitle",
-        "pjs - PJS (Phoenix Japanimation Society) subtitle",
-        "realtext - RealText subtitle",
-        "sami - SAMI subtitle", "stl - Spruce subtitle format",
-        "subviewer - SubViewer subtitle",
-        "subviewer1 - SubViewer v1 subtitle",
-        "text - raw UTF-8 text",
-        "vplayer - VPlayer subtitle",
-        "webvtt - WebVTT subtitle",
-        "xsub - XSUB"
+        new("ass", "ASS (Advanced SSA) subtitle (.ass & .ssa files - often found on anime)"),
+        new("DVDSUB", "DVD subtitles"),
+        new("subrip", "SubRip subtitle (.srt files - most common type of subtitles)"),
+        new("PGSSUB", "HDMV Presentation Graphic Stream subtitles (often found on Blu-ray)"),
+        new("DVBSUB", "DVB subtitles"),
+        new("eia_608", "EIA-608 closed captions"),
+        new("jacosub", "JACOsub subtitle"),
+        new("microdvd", "MicroDVD subtitle"),
+        new("mov_text", "MOV text"),
+        new("mpl2", "MPL2 subtitle"),
+        new("pjs", "PJS (Phoenix Japanimation Society) subtitle"),
+        new("realtext", "RealText subtitle"),
+        new("sami", "SAMI subtitle"),
+        new("stl", "Spruce subtitle format"),
+        new("subviewer", "SubViewer subtitle"),
+        new("subviewer1", "SubViewer v1 subtitle"),
+        new("text", "raw UTF-8 text"),
+        new("vplayer", "VPlayer subtitle"),
+        new("webvtt", "WebVTT subtitle"),
+        new("xsub", "XSUB"),
     ];
 
     /// <summary>
@@ -44,22 +50,22 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>
     /// Gets or sets the list of selected libraries to extract subtitles from (empty means all).
     /// </summary>
-    public string SelectedSubtitlesLibraries { get; set; } = string.Empty;
+    public string[] SelectedSubtitlesLibraries { get; set; } = [];
 
     /// <summary>
     /// Gets or sets the list of selected libraries to extract attachments from (empty means all).
     /// </summary>
-    public string SelectedAttachmentsLibraries { get; set; } = string.Empty;
+    public string[] SelectedAttachmentsLibraries { get; set; } = [];
 
     /// <summary>
     /// Gets all available subtitle codecs.
     /// </summary>
-    public string AllSubtitleCodecs => string.Join("#", _allSubtitleCodecs);
+    public CheckboxItem[] AllSubtitleCodecs => _allSubtitleCodecs;
 
     /// <summary>
     /// Gets or sets the list of codecs to include when extracting subtitle from a media.
     /// </summary>
-    public string SelectedCodecs { get; set; } = string.Join(", ", _allSubtitleCodecs);
+    public string[] SelectedCodecs { get; set; } = _allSubtitleCodecs.Select(x => x.Value).Where(x => !string.IsNullOrEmpty(x)).ToArray()!;
 
     /// <summary>
     /// Gets or sets a value indicating whether advanced codec selection mode is enabled.

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
@@ -85,8 +85,6 @@
 
     <script type="text/javascript">
         function generateCheckboxList(items, selectedItems, containerId) {
-            console.log(items, selectedItems);
-
             const container = document.getElementById(containerId);
             const fragment = document.createDocumentFragment();
             for (const item of items) {

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
@@ -22,7 +22,7 @@
 
                     <div class="folderAccessListContainer" style="margin-bottom: -1em;">
                         <div class="folderAccess">
-                            <h3 class="checkboxListLabel">Limit subtitles extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
+                            <h3 class="checkboxListLabel">Limit subtitle extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
                             <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="librarySubtitlesCheckboxes"></div>
                         </div>
                         <label class="inputLabel" for="SelectedSubtitlesLibraries"></label>
@@ -31,7 +31,7 @@
 
                     <div class="folderAccessListContainer" style="margin-bottom: -1em;">
                         <div class="folderAccess">
-                            <h3 class="checkboxListLabel">Limit attachments extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
+                            <h3 class="checkboxListLabel">Limit attachment extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
                             <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="libraryAttachmentsCheckboxes"></div>
                         </div>
                         <label class="inputLabel" for="SelectedAttachmentsLibraries"></label>
@@ -41,7 +41,46 @@
                     <div class="inputContainer" id="includedCodecsList">
                         <label class="inputLabel inputLabelUnfocused" for="IncludedCodecs"> Included Codecs </label>
                         <input id="IncludedCodecs" type="text" is="emby-input" />
-                        <div class="fieldDescription">Limit subtitles extraction to medias with a stream of the following codecs (separated by a coma - ass,subrip).</div>
+                        <div class="fieldDescription">
+                            Limit subtitle extraction to media containing a stream of the following codecs (separated by a comma).
+                            An empty list means that all codecs are included.
+                        </div>
+                    </div>
+
+                    <div class="inputContainer" id="excludedCodecsList">
+                        <label class="inputLabel inputLabelUnfocused" for="ExcludedCodecs"> Excluded Codecs </label>
+                        <input id="ExcludedCodecs" type="text" is="emby-input" />
+                        <div class="fieldDescription">
+                            Exclude medias with a stream of the following codecs from extraction (separated by a comma).
+                            An empty list means that no codec is excluded.
+                            <br />
+                            <br />
+                            Here is a list of all possible codecs, starting with the most popular ones:
+                            <ul>
+                                <li>ass: ASS (Advanced SSA) subtitle (.ass &amp; .ssa files, often found on anime)</li>
+                                <li>DVDSUB: DVD subtitles</li>
+                                <li>subrip: SubRip subtitle (.srt files, most common type of subtitles)</li>
+                                <li>PGSSUB: HDMV Presentation Graphic Stream subtitles (often found on Blu-ray)</li>
+                            </ul>
+                            <ul>
+                                <li>DVBSUB: DVB subtitles</li>
+                                <li>eia_608: EIA-608 closed captions</li>
+                                <li>jacosub: JACOsub subtitle</li>
+                                <li>microdvd: MicroDVD subtitle</li>
+                                <li>mov_text: MOV text</li>
+                                <li>mpl2: MPL2 subtitle</li>
+                                <li>pjs: PJS (Phoenix Japanimation Society) subtitle</li>
+                                <li>realtext: RealText subtitle</li>
+                                <li>sami: SAMI subtitle</li>
+                                <li>stl: Spruce subtitle format</li>
+                                <li>subviewer: SubViewer subtitle</li>
+                                <li>subviewer1: SubViewer v1 subtitle</li>
+                                <li>text: raw UTF-8 text</li>
+                                <li>vplayer: VPlayer subtitle</li>
+                                <li>webvtt: WebVTT subtitle</li>
+                                <li>xsub: XSUB</li>
+                            </ul>
+                        </div>
                     </div>
 
                     <br />
@@ -139,6 +178,7 @@
                         document.querySelector("#SelectedSubtitlesLibraries").value = config.SelectedSubtitlesLibraries;
                         document.querySelector("#SelectedAttachmentsLibraries").value = config.SelectedAttachmentsLibraries;
                         document.querySelector("#IncludedCodecs").value = config.IncludedCodecs;
+                        document.querySelector("#ExcludedCodecs").value = config.ExcludedCodecs;
 
                         Dashboard.hideLoadingMsg();
                     });
@@ -155,6 +195,7 @@
                         config.SelectedSubtitlesLibraries = document.querySelector("#SelectedSubtitlesLibraries").value;
                         config.SelectedAttachmentsLibraries = document.querySelector("#SelectedAttachmentsLibraries").value;
                         config.IncludedCodecs = document.querySelector("#IncludedCodecs").value;
+                        config.ExcludedCodecs = document.querySelector("#ExcludedCodecs").value;
 
                         ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                     });

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
@@ -20,6 +20,30 @@
                         <div class="fieldDescription checkboxFieldDescription">This will make sure subtitles and attachments are extracted sooner but will result in longer library scans. Does not disable the scheduled task.</div>
                     </div>
 
+                    <div class="folderAccessListContainer" style="margin-bottom: -1em;">
+                        <div class="folderAccess">
+                            <h3 class="checkboxListLabel">Limit subtitles extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
+                            <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="librarySubtitlesCheckboxes"></div>
+                        </div>
+                        <label class="inputLabel" for="SelectedSubtitlesLibraries"></label>
+                        <input id="SelectedSubtitlesLibraries" type="hidden" is="emby-input" />
+                    </div>
+
+                    <div class="folderAccessListContainer" style="margin-bottom: -1em;">
+                        <div class="folderAccess">
+                            <h3 class="checkboxListLabel">Limit attachments extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
+                            <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="libraryAttachmentsCheckboxes"></div>
+                        </div>
+                        <label class="inputLabel" for="SelectedAttachmentsLibraries"></label>
+                        <input id="SelectedAttachmentsLibraries" type="hidden" is="emby-input" />
+                    </div>
+
+                    <div class="inputContainer" id="includedCodecsList">
+                        <label class="inputLabel inputLabelUnfocused" for="IncludedCodecs"> Included Codecs </label>
+                        <input id="IncludedCodecs" type="text" is="emby-input" />
+                        <div class="fieldDescription">Limit subtitles extraction to medias with a stream of the following codecs (separated by a coma - ass,subrip).</div>
+                    </div>
+
                     <br />
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block emby-button"><span>Save</span></button>
@@ -29,6 +53,74 @@
         </div>
 
         <script type="text/javascript">
+
+            function updateList(textField, container) {
+                textField.value = Array.from(container.querySelectorAll('input[type="checkbox"]:checked'))
+                    .map((checkbox) => checkbox.nextElementSibling.textContent)
+                    .join(", ");
+            }
+
+            function generateCheckboxList(items, containerId, textFieldId) {
+                const container = document.getElementById(containerId);
+                const checkedItems = new Set(document.getElementById(textFieldId).value.split(", ").filter(Boolean));
+                const fragment = document.createDocumentFragment();
+                for (const item of items) {
+                    const label = document.createElement("label");
+                    label.className = "emby-checkbox-label";
+                    label.innerHTML = '<input type="checkbox" is="emby-checkbox"' + (checkedItems.has(item) ? " checked" : "") + ">" + '<span class="checkboxLabel">' + item + "</span>";
+                    fragment.appendChild(label);
+                }
+                container.innerHTML = "";
+                container.appendChild(fragment);
+                container.addEventListener(
+                    "change",
+                    (e) => {
+                        if (e.target.type === "checkbox") updateList(document.getElementById(textFieldId), container);
+                    },
+                    { passive: true }
+                );
+            }
+
+            async function populateLibraries() {
+                const response = await getJson("Library/VirtualFolders");
+                const tvLibraries = response.filter((item) => item.CollectionType === undefined || item.CollectionType === "tvshows" || item.CollectionType === "movies");
+                const libraryNames = tvLibraries.map((lib) => lib.Name || "Unnamed Library");
+                generateCheckboxList(libraryNames, "librarySubtitlesCheckboxes", "SelectedSubtitlesLibraries");
+                generateCheckboxList(libraryNames, "libraryAttachmentsCheckboxes", "SelectedAttachmentsLibraries");
+            }
+
+            async function getJson(url) {
+                return await fetchWithAuth(url, "GET")
+                    .then((r) => {
+                        if (r.ok) {
+                            return r.json();
+                        } else {
+                            return null;
+                        }
+                    })
+                    .catch((err) => {
+                        console.debug(err);
+                    });
+            }
+
+            // make an authenticated fetch to the server
+            async function fetchWithAuth(url, method, body) {
+                url = ApiClient.serverAddress() + "/" + url;
+
+                const reqInit = {
+                    method: method,
+                    headers: {
+                        Authorization: "MediaBrowser Token=" + ApiClient.accessToken(),
+                    },
+                    body: body,
+                };
+
+                if (method === "POST") {
+                    reqInit.headers["Content-Type"] = "application/json";
+                }
+
+                return await fetch(url, reqInit);
+            }
 
             (function () {
 
@@ -41,8 +133,12 @@
                     Dashboard.showLoadingMsg();
 
                     ApiClient.getPluginConfiguration(pluginId).then(function (config) {
+                        populateLibraries();
 
                         page.querySelector('#chkEnableDuringScan').checked = !!config.ExtractionDuringLibraryScan;
+                        document.querySelector("#SelectedSubtitlesLibraries").value = config.SelectedSubtitlesLibraries;
+                        document.querySelector("#SelectedAttachmentsLibraries").value = config.SelectedAttachmentsLibraries;
+                        document.querySelector("#IncludedCodecs").value = config.IncludedCodecs;
 
                         Dashboard.hideLoadingMsg();
                     });
@@ -56,6 +152,9 @@
 
                     ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                         config.ExtractionDuringLibraryScan = form.querySelector('#chkEnableDuringScan').checked;
+                        config.SelectedSubtitlesLibraries = document.querySelector("#SelectedSubtitlesLibraries").value;
+                        config.SelectedAttachmentsLibraries = document.querySelector("#SelectedAttachmentsLibraries").value;
+                        config.IncludedCodecs = document.querySelector("#IncludedCodecs").value;
 
                         ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                     });

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
@@ -38,50 +38,19 @@
                         <input id="SelectedAttachmentsLibraries" type="hidden" is="emby-input" />
                     </div>
 
-                    <div class="inputContainer" id="includedCodecsList">
-                        <label class="inputLabel inputLabelUnfocused" for="IncludedCodecs"> Included Codecs </label>
-                        <input id="IncludedCodecs" type="text" is="emby-input" />
-                        <div class="fieldDescription">
-                            Limit subtitle extraction to media containing a stream of the following codecs (separated by a comma).
-                            An empty list means that all codecs are included.
+                    <details id="codecs">
+                        <summary style="cursor: pointer; padding: 10px; width: inherit; margin: auto; border: none; text-align: center; font-size: 1em; outline: 2px solid rgba(155, 155, 155, 0.5);">
+                            Codecs to include in extraction
+                        </summary>
+                        <div class="folderAccessListContainer" style="margin-bottom: -1em;">
+                            <div class="folderAccess">
+                                <h3 class="checkboxListLabel">Limit subtitle extraction to media with all subtitle streams matching the selected codecs.</h3>
+                                <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="includedCodecsCheckboxes"></div>
+                            </div>
+                            <label class="inputLabel" for="SelectedCodecs"></label>
+                            <input id="SelectedCodecs" type="hidden" is="emby-input" />
                         </div>
-                    </div>
-
-                    <div class="inputContainer" id="excludedCodecsList">
-                        <label class="inputLabel inputLabelUnfocused" for="ExcludedCodecs"> Excluded Codecs </label>
-                        <input id="ExcludedCodecs" type="text" is="emby-input" />
-                        <div class="fieldDescription">
-                            Exclude medias with a stream of the following codecs from extraction (separated by a comma).
-                            An empty list means that no codec is excluded.
-                            <br />
-                            <br />
-                            Here is a list of all possible codecs, starting with the most popular ones:
-                            <ul>
-                                <li>ass: ASS (Advanced SSA) subtitle (.ass &amp; .ssa files, often found on anime)</li>
-                                <li>DVDSUB: DVD subtitles</li>
-                                <li>subrip: SubRip subtitle (.srt files, most common type of subtitles)</li>
-                                <li>PGSSUB: HDMV Presentation Graphic Stream subtitles (often found on Blu-ray)</li>
-                            </ul>
-                            <ul>
-                                <li>DVBSUB: DVB subtitles</li>
-                                <li>eia_608: EIA-608 closed captions</li>
-                                <li>jacosub: JACOsub subtitle</li>
-                                <li>microdvd: MicroDVD subtitle</li>
-                                <li>mov_text: MOV text</li>
-                                <li>mpl2: MPL2 subtitle</li>
-                                <li>pjs: PJS (Phoenix Japanimation Society) subtitle</li>
-                                <li>realtext: RealText subtitle</li>
-                                <li>sami: SAMI subtitle</li>
-                                <li>stl: Spruce subtitle format</li>
-                                <li>subviewer: SubViewer subtitle</li>
-                                <li>subviewer1: SubViewer v1 subtitle</li>
-                                <li>text: raw UTF-8 text</li>
-                                <li>vplayer: VPlayer subtitle</li>
-                                <li>webvtt: WebVTT subtitle</li>
-                                <li>xsub: XSUB</li>
-                            </ul>
-                        </div>
-                    </div>
+                    </details>
 
                     <br />
                     <div>
@@ -92,7 +61,6 @@
         </div>
 
         <script type="text/javascript">
-
             function updateList(textField, container) {
                 textField.value = Array.from(container.querySelectorAll('input[type="checkbox"]:checked'))
                     .map((checkbox) => checkbox.nextElementSibling.textContent)
@@ -172,13 +140,14 @@
                     Dashboard.showLoadingMsg();
 
                     ApiClient.getPluginConfiguration(pluginId).then(function (config) {
-                        populateLibraries();
+                        populateLibraries(config);
 
                         page.querySelector('#chkEnableDuringScan').checked = !!config.ExtractionDuringLibraryScan;
                         document.querySelector("#SelectedSubtitlesLibraries").value = config.SelectedSubtitlesLibraries;
                         document.querySelector("#SelectedAttachmentsLibraries").value = config.SelectedAttachmentsLibraries;
-                        document.querySelector("#IncludedCodecs").value = config.IncludedCodecs;
-                        document.querySelector("#ExcludedCodecs").value = config.ExcludedCodecs;
+                        document.querySelector("#SelectedCodecs").value = config.SelectedCodecs;
+
+                        generateCheckboxList(config.AllSubtitleCodecs.split('#'), "includedCodecsCheckboxes", "SelectedCodecs");
 
                         Dashboard.hideLoadingMsg();
                     });
@@ -194,8 +163,7 @@
                         config.ExtractionDuringLibraryScan = form.querySelector('#chkEnableDuringScan').checked;
                         config.SelectedSubtitlesLibraries = document.querySelector("#SelectedSubtitlesLibraries").value;
                         config.SelectedAttachmentsLibraries = document.querySelector("#SelectedAttachmentsLibraries").value;
-                        config.IncludedCodecs = document.querySelector("#IncludedCodecs").value;
-                        config.ExcludedCodecs = document.querySelector("#ExcludedCodecs").value;
+                        config.SelectedCodecs = document.querySelector("#SelectedCodecs").value;
 
                         ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                     });

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
@@ -25,8 +25,6 @@
                         <h3 class="checkboxListLabel">Limit subtitle extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
                         <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="librarySubtitlesCheckboxes"></div>
                     </div>
-                    <label class="inputLabel" for="SelectedSubtitlesLibraries"></label>
-                    <input id="SelectedSubtitlesLibraries" type="hidden" is="emby-input"/>
                 </div>
 
                 <div class="folderAccessListContainer" style="margin-bottom: -1em;">
@@ -34,8 +32,6 @@
                         <h3 class="checkboxListLabel">Limit attachment extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
                         <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="libraryAttachmentsCheckboxes"></div>
                     </div>
-                    <label class="inputLabel" for="SelectedAttachmentsLibraries"></label>
-                    <input id="SelectedAttachmentsLibraries" type="hidden" is="emby-input"/>
                 </div>
 
                 <!-- Easy Mode Section -->
@@ -76,8 +72,6 @@
                             <h3 class="checkboxListLabel">Limit subtitle extraction to media with all subtitle streams matching the selected codecs.</h3>
                             <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="includedCodecsCheckboxes"></div>
                         </div>
-                        <label class="inputLabel" for="SelectedCodecs"></label>
-                        <input id="SelectedCodecs" type="hidden" is="emby-input"/>
                     </div>
                 </details>
 
@@ -90,72 +84,27 @@
     </div>
 
     <script type="text/javascript">
-        function updateList(textField, container) {
-            textField.value = Array.from(container.querySelectorAll('input[type="checkbox"]:checked'))
-                .map((checkbox) => checkbox.nextElementSibling.textContent)
-                .join(", ");
-        }
+        function generateCheckboxList(items, selectedItems, containerId) {
+            console.log(items, selectedItems);
 
-        function generateCheckboxList(items, containerId, textFieldId) {
             const container = document.getElementById(containerId);
-            const checkedItems = new Set(document.getElementById(textFieldId).value.split(", ").filter(Boolean));
             const fragment = document.createDocumentFragment();
             for (const item of items) {
                 const label = document.createElement("label");
                 label.className = "emby-checkbox-label";
-                label.innerHTML = '<input type="checkbox" is="emby-checkbox"' + (checkedItems.has(item) ? " checked" : "") + ">" + '<span class="checkboxLabel">' + item + "</span>";
+                label.innerHTML = '<input type="checkbox" is="emby-checkbox"' + (selectedItems.includes(item.Value) ? " checked" : "") + ' value="' + item.Value + '"><span class="checkboxLabel">' + item.Text + '</span>';
                 fragment.appendChild(label);
             }
             container.innerHTML = "";
             container.appendChild(fragment);
-            container.addEventListener(
-                "change",
-                (e) => {
-                    if (e.target.type === "checkbox") updateList(document.getElementById(textFieldId), container);
-                },
-                {passive: true}
-            );
         }
 
-        async function populateLibraries() {
-            const response = await getJson("Library/VirtualFolders");
+        async function populateLibraries(config) {
+            const response = await window.ApiClient.getVirtualFolders();
             const tvLibraries = response.filter((item) => item.CollectionType === undefined || item.CollectionType === "tvshows" || item.CollectionType === "movies");
-            const libraryNames = tvLibraries.map((lib) => lib.Name || "Unnamed Library");
-            generateCheckboxList(libraryNames, "librarySubtitlesCheckboxes", "SelectedSubtitlesLibraries");
-            generateCheckboxList(libraryNames, "libraryAttachmentsCheckboxes", "SelectedAttachmentsLibraries");
-        }
-
-        async function getJson(url) {
-            return await fetchWithAuth(url, "GET")
-                .then((r) => {
-                    if (r.ok) {
-                        return r.json();
-                    } else {
-                        return null;
-                    }
-                })
-                .catch((err) => {
-                    console.debug(err);
-                });
-        }
-
-        // make an authenticated fetch to the server
-        async function fetchWithAuth(url, method, body) {
-            url = ApiClient.serverAddress() + "/" + url;
-
-            const reqInit = {
-                method: method,
-                headers: {
-                    Authorization: "MediaBrowser Token=" + ApiClient.accessToken(),
-                },
-                body: body,
-            };
-
-            if (method === "POST") {
-                reqInit.headers["Content-Type"] = "application/json";
-            }
-
-            return await fetch(url, reqInit);
+            const libraryNames = tvLibraries.map(lib => ({ Value: lib.Name, Text: lib.Name }));
+            generateCheckboxList(libraryNames, config.SelectedSubtitlesLibraries, "librarySubtitlesCheckboxes");
+            generateCheckboxList(libraryNames, config.SelectedAttachmentsLibraries, "libraryAttachmentsCheckboxes");
         }
 
         function toggleMode(isAdvanced) {
@@ -188,11 +137,8 @@
                     page.querySelector('#chkTextSubtitles').checked = !!config.IncludeTextSubtitles;
                     page.querySelector('#chkGraphicalSubtitles').checked = !!config.IncludeGraphicalSubtitles;
                     page.querySelector('#chkAdvancedMode').checked = !!config.IsAdvancedMode;
-                    document.querySelector("#SelectedSubtitlesLibraries").value = config.SelectedSubtitlesLibraries;
-                    document.querySelector("#SelectedAttachmentsLibraries").value = config.SelectedAttachmentsLibraries;
-                    document.querySelector("#SelectedCodecs").value = config.SelectedCodecs;
 
-                    generateCheckboxList(config.AllSubtitleCodecs.split('#'), "includedCodecsCheckboxes", "SelectedCodecs");
+                    generateCheckboxList(config.AllSubtitleCodecs, config.SelectedCodecs, "includedCodecsCheckboxes");
 
                     const isAdvanced = config.IsAdvancedMode === true;
                     toggleMode(isAdvanced);
@@ -212,9 +158,9 @@
                     config.IncludeTextSubtitles = form.querySelector('#chkTextSubtitles').checked;
                     config.IncludeGraphicalSubtitles = form.querySelector('#chkGraphicalSubtitles').checked;
                     config.IsAdvancedMode = form.querySelector('#chkAdvancedMode').checked;
-                    config.SelectedSubtitlesLibraries = document.querySelector("#SelectedSubtitlesLibraries").value;
-                    config.SelectedAttachmentsLibraries = document.querySelector("#SelectedAttachmentsLibraries").value;
-                    config.SelectedCodecs = document.querySelector("#SelectedCodecs").value;
+                    config.SelectedSubtitlesLibraries = getChecked('librarySubtitlesCheckboxes');
+                    config.SelectedAttachmentsLibraries = getChecked('libraryAttachmentsCheckboxes');
+                    config.SelectedCodecs = getChecked('includedCodecsCheckboxes');
 
                     ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });
@@ -228,6 +174,19 @@
             const isAdvanced = e.target.checked;
             toggleMode(isAdvanced);
         });
+
+        function getChecked(wrapperId)
+        {
+            const nodes = document.getElementById(wrapperId).querySelectorAll('input:checked');
+            let values = [];
+
+            for (const node of nodes)
+            {
+                values.push(node.value);
+            }
+
+            return values;
+        }
     </script>
 </div>
 </body>

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
@@ -4,176 +4,231 @@
     <title>Jellyfin Subtitle Extractor</title>
 </head>
 <body>
-    <div data-role="page" class="page type-interior pluginConfigurationPage subsExtractorConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox,emby-linkbutton">
+<div data-role="page" class="page type-interior pluginConfigurationPage subsExtractorConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox,emby-linkbutton">
 
-        <div data-role="content">
-            <div class="content-primary">
+    <div data-role="content">
+        <div class="content-primary">
 
-                <form class="extractorConfigurationForm">
-                    <br />
+            <form class="extractorConfigurationForm">
+                <br/>
+
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label>
+                        <input is="emby-checkbox" type="checkbox" id="chkEnableDuringScan"/>
+                        <span>Extract subtitles and attachments during library scan</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">This will make sure subtitles and attachments are extracted sooner but will result in longer library scans. Does not disable the scheduled task.</div>
+                </div>
+
+                <div class="folderAccessListContainer" style="margin-bottom: -1em;">
+                    <div class="folderAccess">
+                        <h3 class="checkboxListLabel">Limit subtitle extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
+                        <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="librarySubtitlesCheckboxes"></div>
+                    </div>
+                    <label class="inputLabel" for="SelectedSubtitlesLibraries"></label>
+                    <input id="SelectedSubtitlesLibraries" type="hidden" is="emby-input"/>
+                </div>
+
+                <div class="folderAccessListContainer" style="margin-bottom: -1em;">
+                    <div class="folderAccess">
+                        <h3 class="checkboxListLabel">Limit attachment extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
+                        <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="libraryAttachmentsCheckboxes"></div>
+                    </div>
+                    <label class="inputLabel" for="SelectedAttachmentsLibraries"></label>
+                    <input id="SelectedAttachmentsLibraries" type="hidden" is="emby-input"/>
+                </div>
+
+                <!-- Easy Mode Section -->
+                <div id="easyModeSection">
+                    <h3 class="checkboxListLabel">Subtitle Types to Extract</h3>
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkTextSubtitles"/>
+                            <span>Text Subtitles</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">Includes: SRT, ASS/SSA, WebVTT, and other text-based subtitle formats. It will extract subtitles from medias containing only text subtitles.</div>
+                    </div>
 
                     <div class="checkboxContainer checkboxContainer-withDescription">
                         <label>
-                            <input is="emby-checkbox" type="checkbox" id="chkEnableDuringScan" />
-                            <span>Extract subtitles and attachments during library scan</span>
+                            <input is="emby-checkbox" type="checkbox" id="chkGraphicalSubtitles"/>
+                            <span>Graphical Subtitles</span>
                         </label>
-                        <div class="fieldDescription checkboxFieldDescription">This will make sure subtitles and attachments are extracted sooner but will result in longer library scans. Does not disable the scheduled task.</div>
+                        <div class="fieldDescription checkboxFieldDescription">Includes: DVD subtitles (VOBSUB), Blu-ray subtitles (PGS), and other image-based formats. It will extract subtitles from medias containing at least one graphical subtitle.</div>
                     </div>
+                </div>
 
+                <!-- Advanced Mode Toggle -->
+                <div class="checkboxContainer checkboxContainer-withDescription" style="margin-top: 1.5em;">
+                    <label>
+                        <input is="emby-checkbox" type="checkbox" id="chkAdvancedMode"/>
+                        <span>Advanced Mode</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">Enable advanced codec selection for fine-grained control</div>
+                </div>
+
+                <details id="codecsDetails">
+                    <summary style="cursor: pointer; padding: 10px; width: inherit; margin: auto; border: none; text-align: center; font-size: 1em; outline: 2px solid rgba(155, 155, 155, 0.5);">
+                        Codecs to include in extraction
+                    </summary>
                     <div class="folderAccessListContainer" style="margin-bottom: -1em;">
                         <div class="folderAccess">
-                            <h3 class="checkboxListLabel">Limit subtitle extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
-                            <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="librarySubtitlesCheckboxes"></div>
+                            <h3 class="checkboxListLabel">Limit subtitle extraction to media with all subtitle streams matching the selected codecs.</h3>
+                            <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="includedCodecsCheckboxes"></div>
                         </div>
-                        <label class="inputLabel" for="SelectedSubtitlesLibraries"></label>
-                        <input id="SelectedSubtitlesLibraries" type="hidden" is="emby-input" />
+                        <label class="inputLabel" for="SelectedCodecs"></label>
+                        <input id="SelectedCodecs" type="hidden" is="emby-input"/>
                     </div>
+                </details>
 
-                    <div class="folderAccessListContainer" style="margin-bottom: -1em;">
-                        <div class="folderAccess">
-                            <h3 class="checkboxListLabel">Limit attachment extraction to the following libraries (if nothing is selected, all libraries will be included)</h3>
-                            <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="libraryAttachmentsCheckboxes"></div>
-                        </div>
-                        <label class="inputLabel" for="SelectedAttachmentsLibraries"></label>
-                        <input id="SelectedAttachmentsLibraries" type="hidden" is="emby-input" />
-                    </div>
-
-                    <details id="codecs">
-                        <summary style="cursor: pointer; padding: 10px; width: inherit; margin: auto; border: none; text-align: center; font-size: 1em; outline: 2px solid rgba(155, 155, 155, 0.5);">
-                            Codecs to include in extraction
-                        </summary>
-                        <div class="folderAccessListContainer" style="margin-bottom: -1em;">
-                            <div class="folderAccess">
-                                <h3 class="checkboxListLabel">Limit subtitle extraction to media with all subtitle streams matching the selected codecs.</h3>
-                                <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="includedCodecsCheckboxes"></div>
-                            </div>
-                            <label class="inputLabel" for="SelectedCodecs"></label>
-                            <input id="SelectedCodecs" type="hidden" is="emby-input" />
-                        </div>
-                    </details>
-
-                    <br />
-                    <div>
-                        <button is="emby-button" type="submit" class="raised button-submit block emby-button"><span>Save</span></button>
-                    </div>
-                </form>
-            </div>
+                <br/>
+                <div>
+                    <button is="emby-button" type="submit" class="raised button-submit block emby-button"><span>Save</span></button>
+                </div>
+            </form>
         </div>
-
-        <script type="text/javascript">
-            function updateList(textField, container) {
-                textField.value = Array.from(container.querySelectorAll('input[type="checkbox"]:checked'))
-                    .map((checkbox) => checkbox.nextElementSibling.textContent)
-                    .join(", ");
-            }
-
-            function generateCheckboxList(items, containerId, textFieldId) {
-                const container = document.getElementById(containerId);
-                const checkedItems = new Set(document.getElementById(textFieldId).value.split(", ").filter(Boolean));
-                const fragment = document.createDocumentFragment();
-                for (const item of items) {
-                    const label = document.createElement("label");
-                    label.className = "emby-checkbox-label";
-                    label.innerHTML = '<input type="checkbox" is="emby-checkbox"' + (checkedItems.has(item) ? " checked" : "") + ">" + '<span class="checkboxLabel">' + item + "</span>";
-                    fragment.appendChild(label);
-                }
-                container.innerHTML = "";
-                container.appendChild(fragment);
-                container.addEventListener(
-                    "change",
-                    (e) => {
-                        if (e.target.type === "checkbox") updateList(document.getElementById(textFieldId), container);
-                    },
-                    { passive: true }
-                );
-            }
-
-            async function populateLibraries() {
-                const response = await getJson("Library/VirtualFolders");
-                const tvLibraries = response.filter((item) => item.CollectionType === undefined || item.CollectionType === "tvshows" || item.CollectionType === "movies");
-                const libraryNames = tvLibraries.map((lib) => lib.Name || "Unnamed Library");
-                generateCheckboxList(libraryNames, "librarySubtitlesCheckboxes", "SelectedSubtitlesLibraries");
-                generateCheckboxList(libraryNames, "libraryAttachmentsCheckboxes", "SelectedAttachmentsLibraries");
-            }
-
-            async function getJson(url) {
-                return await fetchWithAuth(url, "GET")
-                    .then((r) => {
-                        if (r.ok) {
-                            return r.json();
-                        } else {
-                            return null;
-                        }
-                    })
-                    .catch((err) => {
-                        console.debug(err);
-                    });
-            }
-
-            // make an authenticated fetch to the server
-            async function fetchWithAuth(url, method, body) {
-                url = ApiClient.serverAddress() + "/" + url;
-
-                const reqInit = {
-                    method: method,
-                    headers: {
-                        Authorization: "MediaBrowser Token=" + ApiClient.accessToken(),
-                    },
-                    body: body,
-                };
-
-                if (method === "POST") {
-                    reqInit.headers["Content-Type"] = "application/json";
-                }
-
-                return await fetch(url, reqInit);
-            }
-
-            (function () {
-
-                var pluginId = "CD893C24-B59E-4060-87B2-184070E1BF68";
-
-                $('.subsExtractorConfigurationPage').on('pageshow', function (event) {
-
-                    var page = this;
-
-                    Dashboard.showLoadingMsg();
-
-                    ApiClient.getPluginConfiguration(pluginId).then(function (config) {
-                        populateLibraries(config);
-
-                        page.querySelector('#chkEnableDuringScan').checked = !!config.ExtractionDuringLibraryScan;
-                        document.querySelector("#SelectedSubtitlesLibraries").value = config.SelectedSubtitlesLibraries;
-                        document.querySelector("#SelectedAttachmentsLibraries").value = config.SelectedAttachmentsLibraries;
-                        document.querySelector("#SelectedCodecs").value = config.SelectedCodecs;
-
-                        generateCheckboxList(config.AllSubtitleCodecs.split('#'), "includedCodecsCheckboxes", "SelectedCodecs");
-
-                        Dashboard.hideLoadingMsg();
-                    });
-                });
-
-                $('.extractorConfigurationForm').off('submit.plugin').on('submit.plugin', function (e) {
-
-                    Dashboard.showLoadingMsg();
-
-                    var form = this;
-
-                    ApiClient.getPluginConfiguration(pluginId).then(function (config) {
-                        config.ExtractionDuringLibraryScan = form.querySelector('#chkEnableDuringScan').checked;
-                        config.SelectedSubtitlesLibraries = document.querySelector("#SelectedSubtitlesLibraries").value;
-                        config.SelectedAttachmentsLibraries = document.querySelector("#SelectedAttachmentsLibraries").value;
-                        config.SelectedCodecs = document.querySelector("#SelectedCodecs").value;
-
-                        ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
-                    });
-
-                    return false;
-                });
-
-            })();
-
-        </script>
     </div>
+
+    <script type="text/javascript">
+        function updateList(textField, container) {
+            textField.value = Array.from(container.querySelectorAll('input[type="checkbox"]:checked'))
+                .map((checkbox) => checkbox.nextElementSibling.textContent)
+                .join(", ");
+        }
+
+        function generateCheckboxList(items, containerId, textFieldId) {
+            const container = document.getElementById(containerId);
+            const checkedItems = new Set(document.getElementById(textFieldId).value.split(", ").filter(Boolean));
+            const fragment = document.createDocumentFragment();
+            for (const item of items) {
+                const label = document.createElement("label");
+                label.className = "emby-checkbox-label";
+                label.innerHTML = '<input type="checkbox" is="emby-checkbox"' + (checkedItems.has(item) ? " checked" : "") + ">" + '<span class="checkboxLabel">' + item + "</span>";
+                fragment.appendChild(label);
+            }
+            container.innerHTML = "";
+            container.appendChild(fragment);
+            container.addEventListener(
+                "change",
+                (e) => {
+                    if (e.target.type === "checkbox") updateList(document.getElementById(textFieldId), container);
+                },
+                {passive: true}
+            );
+        }
+
+        async function populateLibraries() {
+            const response = await getJson("Library/VirtualFolders");
+            const tvLibraries = response.filter((item) => item.CollectionType === undefined || item.CollectionType === "tvshows" || item.CollectionType === "movies");
+            const libraryNames = tvLibraries.map((lib) => lib.Name || "Unnamed Library");
+            generateCheckboxList(libraryNames, "librarySubtitlesCheckboxes", "SelectedSubtitlesLibraries");
+            generateCheckboxList(libraryNames, "libraryAttachmentsCheckboxes", "SelectedAttachmentsLibraries");
+        }
+
+        async function getJson(url) {
+            return await fetchWithAuth(url, "GET")
+                .then((r) => {
+                    if (r.ok) {
+                        return r.json();
+                    } else {
+                        return null;
+                    }
+                })
+                .catch((err) => {
+                    console.debug(err);
+                });
+        }
+
+        // make an authenticated fetch to the server
+        async function fetchWithAuth(url, method, body) {
+            url = ApiClient.serverAddress() + "/" + url;
+
+            const reqInit = {
+                method: method,
+                headers: {
+                    Authorization: "MediaBrowser Token=" + ApiClient.accessToken(),
+                },
+                body: body,
+            };
+
+            if (method === "POST") {
+                reqInit.headers["Content-Type"] = "application/json";
+            }
+
+            return await fetch(url, reqInit);
+        }
+
+        function toggleMode(isAdvanced) {
+            const easyModeSection = document.getElementById('easyModeSection');
+            const codecsDetails = document.getElementById('codecsDetails');
+
+            if (isAdvanced) {
+                easyModeSection.style.display = 'none';
+                codecsDetails.style.display = 'block';
+            } else {
+                easyModeSection.style.display = 'block';
+                codecsDetails.style.display = 'none';
+            }
+        }
+
+        (function () {
+
+            var pluginId = "CD893C24-B59E-4060-87B2-184070E1BF68";
+
+            $('.subsExtractorConfigurationPage').on('pageshow', function (event) {
+
+                var page = this;
+
+                Dashboard.showLoadingMsg();
+
+                ApiClient.getPluginConfiguration(pluginId).then(function (config) {
+                    populateLibraries(config);
+
+                    page.querySelector('#chkEnableDuringScan').checked = !!config.ExtractionDuringLibraryScan;
+                    page.querySelector('#chkTextSubtitles').checked = !!config.IncludeTextSubtitles;
+                    page.querySelector('#chkGraphicalSubtitles').checked = !!config.IncludeGraphicalSubtitles;
+                    page.querySelector('#chkAdvancedMode').checked = !!config.IsAdvancedMode;
+                    document.querySelector("#SelectedSubtitlesLibraries").value = config.SelectedSubtitlesLibraries;
+                    document.querySelector("#SelectedAttachmentsLibraries").value = config.SelectedAttachmentsLibraries;
+                    document.querySelector("#SelectedCodecs").value = config.SelectedCodecs;
+
+                    generateCheckboxList(config.AllSubtitleCodecs.split('#'), "includedCodecsCheckboxes", "SelectedCodecs");
+
+                    const isAdvanced = config.IsAdvancedMode === true;
+                    toggleMode(isAdvanced);
+
+                    Dashboard.hideLoadingMsg();
+                });
+            });
+
+            $('.extractorConfigurationForm').off('submit.plugin').on('submit.plugin', function (e) {
+
+                Dashboard.showLoadingMsg();
+
+                var form = this;
+
+                ApiClient.getPluginConfiguration(pluginId).then(function (config) {
+                    config.ExtractionDuringLibraryScan = form.querySelector('#chkEnableDuringScan').checked;
+                    config.IncludeTextSubtitles = form.querySelector('#chkTextSubtitles').checked;
+                    config.IncludeGraphicalSubtitles = form.querySelector('#chkGraphicalSubtitles').checked;
+                    config.IsAdvancedMode = form.querySelector('#chkAdvancedMode').checked;
+                    config.SelectedSubtitlesLibraries = document.querySelector("#SelectedSubtitlesLibraries").value;
+                    config.SelectedAttachmentsLibraries = document.querySelector("#SelectedAttachmentsLibraries").value;
+                    config.SelectedCodecs = document.querySelector("#SelectedCodecs").value;
+
+                    ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
+                });
+
+                return false;
+            });
+
+        })();
+
+        document.querySelector('#chkAdvancedMode').addEventListener('change', function (e) {
+            const isAdvanced = e.target.checked;
+            toggleMode(isAdvanced);
+        });
+    </script>
+</div>
 </body>
 </html>

--- a/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractAttachmentsTask.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractAttachmentsTask.cs
@@ -67,6 +67,44 @@ public class ExtractAttachmentsTask : IScheduledTask
     /// <inheritdoc />
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
+        var startProgress = 0d;
+
+        var config = SubtitleExtractPlugin.Current.Configuration;
+        var libs = config.SelectedAttachmentsLibraries.Split(",").Select(v => v.Trim()).Where(v => !string.IsNullOrEmpty(v)).ToList();
+
+        List<string> parentIds = [];
+        if (libs.Count > 0)
+        {
+            // Try to get parent ids from the selected libraries
+            parentIds = _libraryManager.GetVirtualFolders().Where(vf => libs.Contains(vf.Name)).Select(vf => vf.ItemId).ToList();
+        }
+
+        if (parentIds.Count > 0)
+        {
+            // In case parent ids are found, run the extraction on each found library
+            foreach (var parentId in parentIds)
+            {
+                startProgress = await RunExtractionWithProgress(progress, parentId, parentIds, startProgress, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            // Otherwise run it on everything
+            await RunExtractionWithProgress(progress, null, [], startProgress, cancellationToken).ConfigureAwait(false);
+        }
+
+        progress.Report(100);
+    }
+
+    private async Task<double> RunExtractionWithProgress(
+        IProgress<double> progress,
+        string? parentId,
+        List<string> parentIds,
+        double startProgress,
+        CancellationToken cancellationToken)
+    {
+        var libsCount = parentIds.Count > 0 ? parentIds.Count : 1;
+
         var query = new InternalItemsQuery
         {
             Recursive = true,
@@ -76,8 +114,17 @@ public class ExtractAttachmentsTask : IScheduledTask
             DtoOptions = _dtoOptions,
             MediaTypes = _mediaTypes,
             SourceTypes = _sourceTypes,
-            Limit = QueryPageLimit,
+            Limit = QueryPageLimit
         };
+
+        var config = SubtitleExtractPlugin.Current!.Configuration;
+        var codecs = config.IncludedCodecs.Trim().Split(",").Select(v => v.Trim()).Where(v => !string.IsNullOrEmpty(v)).ToList();
+
+        if (parentIds.Count > 0 && parentId != null)
+        {
+            // In case parent is provided, add its Guid to the query
+            query.ParentId = Guid.ParseExact(parentId, "N");
+        }
 
         var numberOfVideos = _libraryManager.GetCount(query);
 
@@ -113,12 +160,16 @@ public class ExtractAttachmentsTask : IScheduledTask
                 }
 
                 completedVideos++;
-                progress.Report(100d * completedVideos / numberOfVideos);
+
+                // Report the progress using "startProgress" that allows to track progress across multiple libraries
+                progress.Report(startProgress + (100d * completedVideos / numberOfVideos / libsCount));
             }
 
             startIndex += QueryPageLimit;
         }
 
-        progress.Report(100);
+        // When done, update the startProgress to the current progress for next libraries
+        startProgress += 100d * completedVideos / numberOfVideos / libsCount;
+        return startProgress;
     }
 }

--- a/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractAttachmentsTask.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractAttachmentsTask.cs
@@ -117,9 +117,6 @@ public class ExtractAttachmentsTask : IScheduledTask
             Limit = QueryPageLimit
         };
 
-        var config = SubtitleExtractPlugin.Current!.Configuration;
-        var codecs = config.IncludedCodecs.Trim().Split(",").Select(v => v.Trim()).Where(v => !string.IsNullOrEmpty(v)).ToList();
-
         if (parentIds.Count > 0 && parentId != null)
         {
             // In case parent is provided, add its Guid to the query

--- a/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
@@ -119,6 +119,7 @@ public class ExtractSubtitlesTask : IScheduledTask
         };
 
         var config = SubtitleExtractPlugin.Current.Configuration;
+        // Values are stored separated by comma, and we only need the part before the dash as it is the codec's name.
         var selectedCodecs = config.SelectedCodecs.Trim().Split(",").Select(v => v.Split('-')[0].Trim()).Where(v => !string.IsNullOrEmpty(v)).ToList();
 
         if (parentIds.Count > 0 && parentId != null)

--- a/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
@@ -7,6 +8,8 @@ using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Tasks;
 
@@ -65,6 +68,44 @@ public class ExtractSubtitlesTask : IScheduledTask
     /// <inheritdoc />
     public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
     {
+        var startProgress = 0d;
+
+        var config = SubtitleExtractPlugin.Current!.Configuration;
+        var libs = config.SelectedSubtitlesLibraries.Split(",").Select(v => v.Trim()).Where(v => !string.IsNullOrEmpty(v)).ToList();
+
+        List<string> parentIds = [];
+        if (libs.Count > 0)
+        {
+            // Try to get parent ids from the selected libraries
+            parentIds = _libraryManager.GetVirtualFolders().Where(vf => libs.Contains(vf.Name)).Select(vf => vf.ItemId).ToList();
+        }
+
+        if (parentIds.Count > 0)
+        {
+            // In case parent ids are found, run the extraction on each found library
+            foreach (var parentId in parentIds)
+            {
+                startProgress = await RunExtractionWithProgress(progress, parentId, parentIds, startProgress, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            // Otherwise run it on everything
+            await RunExtractionWithProgress(progress, null, [], startProgress, cancellationToken).ConfigureAwait(false);
+        }
+
+        progress.Report(100);
+    }
+
+    private async Task<double> RunExtractionWithProgress(
+        IProgress<double> progress,
+        string? parentId,
+        List<string> parentIds,
+        double startProgress,
+        CancellationToken cancellationToken)
+    {
+        var libsCount = parentIds.Count > 0 ? parentIds.Count : 1;
+
         var query = new InternalItemsQuery
         {
             Recursive = true,
@@ -74,8 +115,17 @@ public class ExtractSubtitlesTask : IScheduledTask
             DtoOptions = _dtoOptions,
             MediaTypes = _mediaTypes,
             SourceTypes = _sourceTypes,
-            Limit = QueryPageLimit,
+            Limit = QueryPageLimit
         };
+
+        var config = SubtitleExtractPlugin.Current.Configuration;
+        var codecs = config.IncludedCodecs.Trim().Split(",").Select(v => v.Trim()).Where(v => !string.IsNullOrEmpty(v)).ToList();
+
+        if (parentIds.Count > 0 && parentId != null)
+        {
+            // In case parent is provided, add its Guid to the query
+            query.ParentId = Guid.ParseExact(parentId, "N");
+        }
 
         var numberOfVideos = _libraryManager.GetCount(query);
 
@@ -91,18 +141,33 @@ public class ExtractSubtitlesTask : IScheduledTask
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                foreach (var mediaSource in video.GetMediaSources(false))
+                foreach (var mediaSource in video.GetMediaSources(false).Where(source => FilterMediasWithCodec(codecs, source)))
                 {
                     await _encoder.ExtractAllExtractableSubtitles(mediaSource, cancellationToken).ConfigureAwait(false);
                 }
 
                 completedVideos++;
-                progress.Report(100d * completedVideos / numberOfVideos);
+
+                // Report the progress using "startProgress" that allows to track progress across multiple libraries
+                progress.Report(startProgress + (100d * completedVideos / numberOfVideos / libsCount));
             }
 
             startIndex += QueryPageLimit;
         }
 
-        progress.Report(100);
+        // When done, update the startProgress to the current progress for next libraries
+        startProgress += 100d * completedVideos / numberOfVideos / libsCount;
+        return startProgress;
+    }
+
+    /// <summary>
+    /// Filters given media depending on a subtitle stream containing one of the given codecs.
+    /// </summary>
+    /// <param name="codecs">The list of codecs to check.</param>
+    /// <param name="source">the media source.</param>
+    /// <returns>True if media should be handled.</returns>
+    private static bool FilterMediasWithCodec(List<string> codecs, MediaSourceInfo source)
+    {
+        return codecs.Count == 0 || source.MediaStreams.Any(stream => stream.Type == MediaStreamType.Subtitle && codecs.Contains(stream.Codec));
     }
 }

--- a/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
@@ -162,7 +162,7 @@ public class ExtractSubtitlesTask : IScheduledTask
     }
 
     /// <summary>
-    /// Filters given media depending on codecs to include or exclude.
+    /// Filters given media depending on codecs to include.
     /// </summary>
     /// <param name="selectedCodecs">The list of codecs to include.</param>
     /// <param name="source">the media source.</param>

--- a/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
@@ -170,11 +170,6 @@ public class ExtractSubtitlesTask : IScheduledTask
     /// <returns>True if media should be handled.</returns>
     private static bool FilterMediasWithCodec(List<string> includedCodecs, List<string> excludedCodecs, MediaSourceInfo source)
     {
-        if (includedCodecs.Count == 0 && excludedCodecs.Count == 0)
-        {
-            return true;
-        }
-
         var hasIncludedCodecs = includedCodecs.Count == 0 || source.MediaStreams.Any(stream => stream.Type == MediaStreamType.Subtitle && includedCodecs.Contains(stream.Codec, StringComparer.CurrentCultureIgnoreCase));
         var hasExcludedCodecs = excludedCodecs.Count > 0 && source.MediaStreams.Any(stream => stream.Type == MediaStreamType.Subtitle && excludedCodecs.Contains(stream.Codec, StringComparer.CurrentCultureIgnoreCase));
         return hasIncludedCodecs && !hasExcludedCodecs;


### PR DESCRIPTION
Hello I remade the PR for adding libraries selection ability (it was easier than resolving conflicts).

Re-dropping the text from previous PR:
This PR adds a way to select which libraries to extract subtitles from.
It also adds a way to filter medias by codec. For example if we require only medias with ASS subtitles to be extracted instead of all medias.

Feel free to make feedbacks if needed.

Is there any chance you take a look at it @crobibero @Shadowghost  ?

<img width="879" height="764" alt="image" src="https://github.com/user-attachments/assets/d02d9388-0fa2-4b97-b9c1-615c472b3137" />
