### PR TITLE
 Add advanced subtitle filtering settings and optional worker threads

### DIFF
--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
@@ -1,6 +1,5 @@
 #pragma warning disable CA1819 // Properties should not return arrays
 
-using System.Linq;
 using MediaBrowser.Model.Plugins;
 
 namespace Jellyfin.Plugin.SubtitleExtract.Configuration;
@@ -12,26 +11,106 @@ public class PluginConfiguration : BasePluginConfiguration
 {
     private static readonly CheckboxItem[] _allSubtitleCodecs =
     [
-        new("ass", "ASS (Advanced SSA) subtitle (.ass & .ssa files - often found on anime)"),
-        new("DVDSUB", "DVD subtitles"),
-        new("subrip", "SubRip subtitle (.srt files - most common type of subtitles)"),
-        new("PGSSUB", "HDMV Presentation Graphic Stream subtitles (often found on Blu-ray)"),
-        new("DVBSUB", "DVB subtitles"),
-        new("eia_608", "EIA-608 closed captions"),
-        new("jacosub", "JACOsub subtitle"),
-        new("microdvd", "MicroDVD subtitle"),
-        new("mov_text", "MOV text"),
-        new("mpl2", "MPL2 subtitle"),
-        new("pjs", "PJS (Phoenix Japanimation Society) subtitle"),
-        new("realtext", "RealText subtitle"),
-        new("sami", "SAMI subtitle"),
-        new("stl", "Spruce subtitle format"),
-        new("subviewer", "SubViewer subtitle"),
-        new("subviewer1", "SubViewer v1 subtitle"),
-        new("text", "raw UTF-8 text"),
-        new("vplayer", "VPlayer subtitle"),
-        new("webvtt", "WebVTT subtitle"),
+        new("ass", "ASS / SSA"),
+        new("DVDSUB", "DVD (VOBSUB)"),
+        new("subrip", "SubRip (SRT)"),
+        new("PGSSUB", "PGS (Blu-ray)"),
+        new("DVBSUB", "DVB"),
+        new("eia_608", "EIA-608 (CC)"),
+        new("jacosub", "JACOsub"),
+        new("microdvd", "MicroDVD"),
+        new("mov_text", "MOV Text"),
+        new("mpl2", "MPL2"),
+        new("pjs", "PJS"),
+        new("realtext", "RealText"),
+        new("sami", "SAMI"),
+        new("stl", "Spruce STL"),
+        new("subviewer", "SubViewer"),
+        new("subviewer1", "SubViewer v1"),
+        new("text", "Raw Text"),
+        new("vplayer", "VPlayer"),
+        new("webvtt", "WebVTT"),
         new("xsub", "XSUB"),
+    ];
+
+    private static readonly CheckboxItem[] _allLanguages =
+    [
+        new("und", "Undefined / Untagged"),
+        new("afr", "Afrikaans"),
+        new("alb", "Albanian"),
+        new("ara", "Arabic"),
+        new("arm", "Armenian"),
+        new("aze", "Azerbaijani"),
+        new("baq", "Basque"),
+        new("bel", "Belarusian"),
+        new("ben", "Bengali"),
+        new("bos", "Bosnian"),
+        new("bul", "Bulgarian"),
+        new("bur", "Burmese"),
+        new("cat", "Catalan"),
+        new("chi", "Chinese"),
+        new("hrv", "Croatian"),
+        new("cze", "Czech"),
+        new("dan", "Danish"),
+        new("dut", "Dutch"),
+        new("eng", "English"),
+        new("est", "Estonian"),
+        new("fil", "Filipino"),
+        new("fin", "Finnish"),
+        new("fre", "French"),
+        new("geo", "Georgian"),
+        new("ger", "German"),
+        new("gre", "Greek"),
+        new("guj", "Gujarati"),
+        new("heb", "Hebrew"),
+        new("hin", "Hindi"),
+        new("hun", "Hungarian"),
+        new("ice", "Icelandic"),
+        new("ind", "Indonesian"),
+        new("gle", "Irish"),
+        new("ita", "Italian"),
+        new("jpn", "Japanese"),
+        new("kan", "Kannada"),
+        new("kaz", "Kazakh"),
+        new("khm", "Khmer"),
+        new("kor", "Korean"),
+        new("kur", "Kurdish"),
+        new("lao", "Lao"),
+        new("lav", "Latvian"),
+        new("lit", "Lithuanian"),
+        new("mac", "Macedonian"),
+        new("may", "Malay"),
+        new("mal", "Malayalam"),
+        new("mar", "Marathi"),
+        new("mon", "Mongolian"),
+        new("nep", "Nepali"),
+        new("nor", "Norwegian"),
+        new("nob", "Norwegian Bokmal"),
+        new("nno", "Norwegian Nynorsk"),
+        new("per", "Persian"),
+        new("pol", "Polish"),
+        new("por", "Portuguese"),
+        new("pan", "Punjabi"),
+        new("rum", "Romanian"),
+        new("rus", "Russian"),
+        new("srp", "Serbian"),
+        new("sin", "Sinhala"),
+        new("slo", "Slovak"),
+        new("slv", "Slovenian"),
+        new("spa", "Spanish"),
+        new("swa", "Swahili"),
+        new("swe", "Swedish"),
+        new("tam", "Tamil"),
+        new("tel", "Telugu"),
+        new("tha", "Thai"),
+        new("tur", "Turkish"),
+        new("ukr", "Ukrainian"),
+        new("urd", "Urdu"),
+        new("uzb", "Uzbek"),
+        new("vie", "Vietnamese"),
+        new("wel", "Welsh"),
+        new("yid", "Yiddish"),
+        new("zul", "Zulu"),
     ];
 
     /// <summary>
@@ -42,8 +121,7 @@ public class PluginConfiguration : BasePluginConfiguration
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether or not to extract subtitles and attachments as part of library scan.
-    /// default = false.
+    /// Gets or sets a value indicating whether to extract subtitles and attachments during library scan.
     /// </summary>
     public bool ExtractionDuringLibraryScan { get; set; } = false;
 
@@ -58,27 +136,69 @@ public class PluginConfiguration : BasePluginConfiguration
     public string[] SelectedAttachmentsLibraries { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets a value indicating whether to extract all languages regardless of selection.
+    /// </summary>
+    public bool ExtractAllLanguages { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the list of selected subtitle languages to extract.
+    /// </summary>
+    public string[] SelectedLanguages { get; set; } = [];
+
+    /// <summary>
+    /// Gets all available subtitle languages.
+    /// </summary>
+    public CheckboxItem[] AllLanguages => _allLanguages;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to extract all codec types regardless of selection.
+    /// </summary>
+    public bool ExtractAllCodecTypes { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the list of selected subtitle codec types to extract.
+    /// </summary>
+    public string[] SelectedCodecTypes { get; set; } = [];
+
+    /// <summary>
     /// Gets all available subtitle codecs.
     /// </summary>
     public CheckboxItem[] AllSubtitleCodecs => _allSubtitleCodecs;
 
     /// <summary>
-    /// Gets or sets the list of codecs to include when extracting subtitle from a media.
+    /// Gets or sets the regex pattern for accepting subtitles by title. Only subtitles matching this pattern are extracted.
     /// </summary>
-    public string[] SelectedCodecs { get; set; } = _allSubtitleCodecs.Select(x => x.Value).Where(x => !string.IsNullOrEmpty(x)).ToArray()!;
+    public string AcceptTitleRegex { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets a value indicating whether advanced codec selection mode is enabled.
+    /// Gets or sets the regex pattern for rejecting subtitles by title. Subtitles matching this pattern are skipped (takes precedence over accept).
     /// </summary>
-    public bool IsAdvancedMode { get; set; }
+    public string RejectTitleRegex { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets a value indicating whether advanced codec selection mode is enabled.
+    /// Gets or sets a value indicating whether the accept override expression is enabled.
     /// </summary>
-    public bool IncludeTextSubtitles { get; set; } = true;
+    public bool AcceptOverrideEnabled { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets a value indicating whether advanced codec selection mode is enabled.
+    /// Gets or sets the accept override expression. When enabled and evaluates to true, the subtitle is extracted regardless of other filters.
+    /// Uses C# syntax with variables: LANGUAGE, TYPE, TITLE.
     /// </summary>
-    public bool IncludeGraphicalSubtitles { get; set; } = true;
+    public string AcceptOverrideExpression { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the reject override expression is enabled.
+    /// </summary>
+    public bool RejectOverrideEnabled { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the reject override expression. When enabled and evaluates to true, the subtitle is skipped regardless of other filters.
+    /// Uses C# syntax with variables: LANGUAGE, TYPE, TITLE.
+    /// </summary>
+    public string RejectOverrideExpression { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of worker threads for parallel subtitle extraction.
+    /// </summary>
+    public int WorkerThreads { get; set; } = 1;
 }

--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/configPage.html
@@ -2,6 +2,53 @@
 <html>
 <head>
     <title>Jellyfin Subtitle Extractor</title>
+    <style>
+        .checkbox-grid {
+            display: grid;
+            grid-template-columns: repeat(6, 1fr);
+            gap: 0.25em 0.5em;
+            padding: 0.5em 1em;
+        }
+        .checkbox-grid label {
+            display: flex;
+            align-items: center;
+            gap: 0.3em;
+            font-size: 0.9em;
+            white-space: nowrap;
+        }
+        .checkbox-grid-container {
+            margin-bottom: 1em;
+        }
+        .checkbox-grid-container.disabled {
+            opacity: 0.4;
+            pointer-events: none;
+        }
+        .master-checkbox {
+            margin-bottom: 0.5em;
+        }
+        .section-header {
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+            border-bottom: 1px solid rgba(155, 155, 155, 0.3);
+            padding-bottom: 0.3em;
+        }
+        .regex-section {
+            margin-top: 1em;
+        }
+        .regex-section .inputContainer {
+            margin-bottom: 1em;
+        }
+        .regex-section input[type="text"] {
+            width: 100%;
+            font-family: monospace;
+        }
+        .worker-section {
+            margin-top: 1em;
+        }
+        .worker-section input[type="number"] {
+            width: 80px;
+        }
+    </style>
 </head>
 <body>
 <div data-role="page" class="page type-interior pluginConfigurationPage subsExtractorConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox,emby-linkbutton">
@@ -34,46 +81,95 @@
                     </div>
                 </div>
 
-                <!-- Easy Mode Section -->
-                <div id="easyModeSection">
-                    <h3 class="checkboxListLabel">Subtitle Types to Extract</h3>
-                    <div class="checkboxContainer checkboxContainer-withDescription">
-                        <label>
-                            <input is="emby-checkbox" type="checkbox" id="chkTextSubtitles"/>
-                            <span>Text Subtitles</span>
-                        </label>
-                        <div class="fieldDescription checkboxFieldDescription">Includes: SRT, ASS/SSA, WebVTT, and other text-based subtitle formats. It will extract subtitles from medias containing only text subtitles.</div>
-                    </div>
-
-                    <div class="checkboxContainer checkboxContainer-withDescription">
-                        <label>
-                            <input is="emby-checkbox" type="checkbox" id="chkGraphicalSubtitles"/>
-                            <span>Graphical Subtitles</span>
-                        </label>
-                        <div class="fieldDescription checkboxFieldDescription">Includes: DVD subtitles (VOBSUB), Blu-ray subtitles (PGS), and other image-based formats. It will extract subtitles from medias containing at least one graphical subtitle.</div>
-                    </div>
-                </div>
-
-                <!-- Advanced Mode Toggle -->
-                <div class="checkboxContainer checkboxContainer-withDescription" style="margin-top: 1.5em;">
+                <!-- Languages Section -->
+                <h3 class="section-header">Subtitle Languages</h3>
+                <div class="master-checkbox">
                     <label>
-                        <input is="emby-checkbox" type="checkbox" id="chkAdvancedMode"/>
-                        <span>Advanced Mode</span>
+                        <input is="emby-checkbox" type="checkbox" id="chkExtractAllLanguages"/>
+                        <span>Extract all languages</span>
                     </label>
-                    <div class="fieldDescription checkboxFieldDescription">Enable advanced codec selection for fine-grained control</div>
+                    <div class="fieldDescription checkboxFieldDescription">When enabled, subtitles in all languages will be extracted. Disable to select specific languages below.</div>
+                </div>
+                <div class="checkbox-grid-container" id="languageGridContainer">
+                    <div class="checkbox-grid" id="languageCheckboxes"></div>
                 </div>
 
-                <details id="codecsDetails">
-                    <summary style="cursor: pointer; padding: 10px; width: inherit; margin: auto; border: none; text-align: center; font-size: 1em; outline: 2px solid rgba(155, 155, 155, 0.5);">
-                        Codecs to include in extraction
-                    </summary>
-                    <div class="folderAccessListContainer" style="margin-bottom: -1em;">
-                        <div class="folderAccess">
-                            <h3 class="checkboxListLabel">Limit subtitle extraction to media with all subtitle streams matching the selected codecs.</h3>
-                            <div class="checkboxList paperList" style="padding: 0.5em 1em;" id="includedCodecsCheckboxes"></div>
-                        </div>
+                <!-- Subtitle Types Section -->
+                <h3 class="section-header">Subtitle Types</h3>
+                <div class="master-checkbox">
+                    <label>
+                        <input is="emby-checkbox" type="checkbox" id="chkExtractAllCodecTypes"/>
+                        <span>Extract all subtitle types</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">When enabled, all subtitle formats will be extracted. Disable to select specific types below.</div>
+                </div>
+                <div class="checkbox-grid-container" id="codecGridContainer">
+                    <div class="checkbox-grid" id="codecCheckboxes"></div>
+                </div>
+
+                <!-- Regex Filters Section -->
+                <h3 class="section-header">Title Regex Filters</h3>
+                <div class="regex-section">
+                    <div class="inputContainer">
+                        <label class="inputLabel" for="txtAcceptRegex">Accept Pattern (only extract subtitles whose title matches this regex)</label>
+                        <input is="emby-input" type="text" id="txtAcceptRegex" placeholder="e.g. ^English|^Commentary"/>
+                        <div class="fieldDescription">Leave empty to accept all. Only subtitles with titles matching this pattern will be extracted.</div>
                     </div>
-                </details>
+                    <div class="inputContainer">
+                        <label class="inputLabel" for="txtRejectRegex">Reject Pattern (skip subtitles whose title matches this regex)</label>
+                        <input is="emby-input" type="text" id="txtRejectRegex" placeholder="e.g. Signs|Songs|Forced"/>
+                        <div class="fieldDescription">Leave empty to reject none. Subtitles with titles matching this pattern will be skipped. <strong>Rejection takes precedence over acceptance.</strong></div>
+                    </div>
+                </div>
+
+                <!-- Override Expressions Section -->
+                <h3 class="section-header">Override Expressions</h3>
+                <div class="fieldDescription" style="margin-bottom: 1em;">
+                    Boolean expressions using C# syntax that override the normal filters above. Available variables:
+                    <strong>LANGUAGE</strong> (e.g. "eng", "jpn", "und"),
+                    <strong>TYPE</strong> (e.g. "subrip", "ass", "PGSSUB"),
+                    <strong>TITLE</strong> (the subtitle track title).
+                    You can use standard C# string methods and operators: <code>==</code>, <code>!=</code>, <code>&&</code>, <code>||</code>, <code>!</code>,
+                    <code>.Contains()</code>, <code>.StartsWith()</code>, <code>.EndsWith()</code>.
+                </div>
+
+                <div style="margin-bottom: 1.5em;">
+                    <div class="checkboxContainer" style="margin-bottom: 0.5em;">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkAcceptOverride"/>
+                            <span>Enable Accept Override</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">When enabled, subtitles matching this expression are <strong>always extracted</strong>, bypassing all other filters.</div>
+                    </div>
+                    <div id="acceptOverrideContainer">
+                        <textarea is="emby-input" id="txtAcceptOverride" rows="3" style="width: 100%; font-family: monospace; resize: vertical;"
+                            placeholder='e.g. LANGUAGE == "eng" && TYPE == "subrip"'></textarea>
+                    </div>
+                </div>
+
+                <div style="margin-bottom: 1.5em;">
+                    <div class="checkboxContainer" style="margin-bottom: 0.5em;">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkRejectOverride"/>
+                            <span>Enable Reject Override</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">When enabled, subtitles matching this expression are <strong>always skipped</strong>, regardless of all other filters. Takes precedence over accept override.</div>
+                    </div>
+                    <div id="rejectOverrideContainer">
+                        <textarea is="emby-input" id="txtRejectOverride" rows="3" style="width: 100%; font-family: monospace; resize: vertical;"
+                            placeholder='e.g. TITLE.Contains("Signs") || TITLE.Contains("Songs")'></textarea>
+                    </div>
+                </div>
+
+                <!-- Worker Threads Section -->
+                <h3 class="section-header">Performance</h3>
+                <div class="worker-section">
+                    <div class="inputContainer">
+                        <label class="inputLabel" for="txtWorkerThreads">Worker Threads</label>
+                        <input is="emby-input" type="number" id="txtWorkerThreads" min="1" max="32" step="1"/>
+                        <div class="fieldDescription">Number of parallel worker threads for subtitle extraction tasks. Default: 1.</div>
+                    </div>
+                </div>
 
                 <br/>
                 <div>
@@ -97,6 +193,18 @@
             container.appendChild(fragment);
         }
 
+        function generateCheckboxGrid(items, selectedItems, containerId) {
+            const container = document.getElementById(containerId);
+            const fragment = document.createDocumentFragment();
+            for (const item of items) {
+                const label = document.createElement("label");
+                label.innerHTML = '<input type="checkbox" is="emby-checkbox"' + (selectedItems.includes(item.Value) ? " checked" : "") + ' value="' + item.Value + '"><span>' + item.Text + '</span>';
+                fragment.appendChild(label);
+            }
+            container.innerHTML = "";
+            container.appendChild(fragment);
+        }
+
         async function populateLibraries(config) {
             const response = await window.ApiClient.getVirtualFolders();
             const tvLibraries = response.filter((item) => item.CollectionType === undefined || item.CollectionType === "tvshows" || item.CollectionType === "movies");
@@ -105,17 +213,33 @@
             generateCheckboxList(libraryNames, config.SelectedAttachmentsLibraries, "libraryAttachmentsCheckboxes");
         }
 
-        function toggleMode(isAdvanced) {
-            const easyModeSection = document.getElementById('easyModeSection');
-            const codecsDetails = document.getElementById('codecsDetails');
-
-            if (isAdvanced) {
-                easyModeSection.style.display = 'none';
-                codecsDetails.style.display = 'block';
+        function updateOverrideState(checkboxId, containerId) {
+            const chk = document.getElementById(checkboxId);
+            const container = document.getElementById(containerId);
+            if (chk.checked) {
+                container.classList.remove('disabled');
             } else {
-                easyModeSection.style.display = 'block';
-                codecsDetails.style.display = 'none';
+                container.classList.add('disabled');
             }
+        }
+
+        function updateGridState(masterCheckboxId, gridContainerId) {
+            const master = document.getElementById(masterCheckboxId);
+            const container = document.getElementById(gridContainerId);
+            if (master.checked) {
+                container.classList.add('disabled');
+            } else {
+                container.classList.remove('disabled');
+            }
+        }
+
+        function getChecked(wrapperId) {
+            const nodes = document.getElementById(wrapperId).querySelectorAll('input:checked');
+            let values = [];
+            for (const node of nodes) {
+                values.push(node.value);
+            }
+            return values;
         }
 
         (function () {
@@ -132,14 +256,31 @@
                     populateLibraries(config);
 
                     page.querySelector('#chkEnableDuringScan').checked = !!config.ExtractionDuringLibraryScan;
-                    page.querySelector('#chkTextSubtitles').checked = !!config.IncludeTextSubtitles;
-                    page.querySelector('#chkGraphicalSubtitles').checked = !!config.IncludeGraphicalSubtitles;
-                    page.querySelector('#chkAdvancedMode').checked = !!config.IsAdvancedMode;
 
-                    generateCheckboxList(config.AllSubtitleCodecs, config.SelectedCodecs, "includedCodecsCheckboxes");
+                    // Language settings
+                    page.querySelector('#chkExtractAllLanguages').checked = config.ExtractAllLanguages !== false;
+                    generateCheckboxGrid(config.AllLanguages, config.SelectedLanguages || [], "languageCheckboxes");
+                    updateGridState('chkExtractAllLanguages', 'languageGridContainer');
 
-                    const isAdvanced = config.IsAdvancedMode === true;
-                    toggleMode(isAdvanced);
+                    // Codec type settings
+                    page.querySelector('#chkExtractAllCodecTypes').checked = config.ExtractAllCodecTypes !== false;
+                    generateCheckboxGrid(config.AllSubtitleCodecs, config.SelectedCodecTypes || [], "codecCheckboxes");
+                    updateGridState('chkExtractAllCodecTypes', 'codecGridContainer');
+
+                    // Regex settings
+                    page.querySelector('#txtAcceptRegex').value = config.AcceptTitleRegex || '';
+                    page.querySelector('#txtRejectRegex').value = config.RejectTitleRegex || '';
+
+                    // Override expressions
+                    page.querySelector('#chkAcceptOverride').checked = !!config.AcceptOverrideEnabled;
+                    page.querySelector('#txtAcceptOverride').value = config.AcceptOverrideExpression || '';
+                    page.querySelector('#chkRejectOverride').checked = !!config.RejectOverrideEnabled;
+                    page.querySelector('#txtRejectOverride').value = config.RejectOverrideExpression || '';
+                    updateOverrideState('chkAcceptOverride', 'acceptOverrideContainer');
+                    updateOverrideState('chkRejectOverride', 'rejectOverrideContainer');
+
+                    // Worker threads
+                    page.querySelector('#txtWorkerThreads').value = config.WorkerThreads || 1;
 
                     Dashboard.hideLoadingMsg();
                 });
@@ -153,12 +294,30 @@
 
                 ApiClient.getPluginConfiguration(pluginId).then(function (config) {
                     config.ExtractionDuringLibraryScan = form.querySelector('#chkEnableDuringScan').checked;
-                    config.IncludeTextSubtitles = form.querySelector('#chkTextSubtitles').checked;
-                    config.IncludeGraphicalSubtitles = form.querySelector('#chkGraphicalSubtitles').checked;
-                    config.IsAdvancedMode = form.querySelector('#chkAdvancedMode').checked;
                     config.SelectedSubtitlesLibraries = getChecked('librarySubtitlesCheckboxes');
                     config.SelectedAttachmentsLibraries = getChecked('libraryAttachmentsCheckboxes');
-                    config.SelectedCodecs = getChecked('includedCodecsCheckboxes');
+
+                    // Language settings
+                    config.ExtractAllLanguages = form.querySelector('#chkExtractAllLanguages').checked;
+                    config.SelectedLanguages = getChecked('languageCheckboxes');
+
+                    // Codec type settings
+                    config.ExtractAllCodecTypes = form.querySelector('#chkExtractAllCodecTypes').checked;
+                    config.SelectedCodecTypes = getChecked('codecCheckboxes');
+
+                    // Regex settings
+                    config.AcceptTitleRegex = form.querySelector('#txtAcceptRegex').value.trim();
+                    config.RejectTitleRegex = form.querySelector('#txtRejectRegex').value.trim();
+
+                    // Override expressions
+                    config.AcceptOverrideEnabled = form.querySelector('#chkAcceptOverride').checked;
+                    config.AcceptOverrideExpression = form.querySelector('#txtAcceptOverride').value;
+                    config.RejectOverrideEnabled = form.querySelector('#chkRejectOverride').checked;
+                    config.RejectOverrideExpression = form.querySelector('#txtRejectOverride').value;
+
+                    // Worker threads
+                    var threads = parseInt(form.querySelector('#txtWorkerThreads').value, 10);
+                    config.WorkerThreads = isNaN(threads) || threads < 1 ? 1 : Math.min(threads, 32);
 
                     ApiClient.updatePluginConfiguration(pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });
@@ -168,23 +327,21 @@
 
         })();
 
-        document.querySelector('#chkAdvancedMode').addEventListener('change', function (e) {
-            const isAdvanced = e.target.checked;
-            toggleMode(isAdvanced);
+        document.querySelector('#chkExtractAllLanguages').addEventListener('change', function () {
+            updateGridState('chkExtractAllLanguages', 'languageGridContainer');
         });
 
-        function getChecked(wrapperId)
-        {
-            const nodes = document.getElementById(wrapperId).querySelectorAll('input:checked');
-            let values = [];
+        document.querySelector('#chkExtractAllCodecTypes').addEventListener('change', function () {
+            updateGridState('chkExtractAllCodecTypes', 'codecGridContainer');
+        });
 
-            for (const node of nodes)
-            {
-                values.push(node.value);
-            }
+        document.querySelector('#chkAcceptOverride').addEventListener('change', function () {
+            updateOverrideState('chkAcceptOverride', 'acceptOverrideContainer');
+        });
 
-            return values;
-        }
+        document.querySelector('#chkRejectOverride').addEventListener('change', function () {
+            updateOverrideState('chkRejectOverride', 'rejectOverrideContainer');
+        });
     </script>
 </div>
 </body>

--- a/Jellyfin.Plugin.SubtitleExtract/Jellyfin.Plugin.SubtitleExtract.csproj
+++ b/Jellyfin.Plugin.SubtitleExtract/Jellyfin.Plugin.SubtitleExtract.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="DynamicExpresso.Core" Version="2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.SubtitleExtract/Providers/SubtitleExtractionProvider.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Providers/SubtitleExtractionProvider.cs
@@ -87,7 +87,11 @@ public class SubtitleExtractionProvider : ICustomMetadataProvider<Episode>,
 
             foreach (var mediaSource in item.GetMediaSources(false))
             {
-                await _encoder.ExtractAllExtractableSubtitles(mediaSource, cancellationToken).ConfigureAwait(false);
+                var filtered = SubtitleStreamFilter.FilterMediaSource(mediaSource, config);
+                if (filtered is not null)
+                {
+                    await _encoder.ExtractAllExtractableSubtitles(filtered, cancellationToken).ConfigureAwait(false);
+                }
             }
 
             _logger.LogDebug("Finished subtitle extraction for: {Video}", item.Path);

--- a/Jellyfin.Plugin.SubtitleExtract/SubtitleStreamFilter.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/SubtitleStreamFilter.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using DynamicExpresso;
+using Jellyfin.Plugin.SubtitleExtract.Configuration;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.SubtitleExtract;
+
+/// <summary>
+/// Provides filtering logic for subtitle streams based on plugin configuration.
+/// </summary>
+public static class SubtitleStreamFilter
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Determines whether a subtitle stream should be extracted based on configuration.
+    /// </summary>
+    /// <param name="stream">The subtitle stream to evaluate.</param>
+    /// <param name="config">The plugin configuration.</param>
+    /// <returns>True if the stream should be extracted.</returns>
+    public static bool ShouldExtractStream(MediaStream stream, PluginConfiguration config)
+    {
+        var language = string.IsNullOrEmpty(stream.Language) ? "und" : stream.Language;
+        var codec = stream.Codec ?? string.Empty;
+        var title = stream.Title ?? string.Empty;
+
+        // Override expressions take priority over all other filters
+        // Reject override: if enabled and matches, skip immediately
+        if (config.RejectOverrideEnabled && !string.IsNullOrWhiteSpace(config.RejectOverrideExpression))
+        {
+            if (EvaluateExpression(config.RejectOverrideExpression, language, codec, title))
+            {
+                return false;
+            }
+        }
+
+        // Accept override: if enabled and matches, accept immediately (bypass normal filters)
+        if (config.AcceptOverrideEnabled && !string.IsNullOrWhiteSpace(config.AcceptOverrideExpression))
+        {
+            if (EvaluateExpression(config.AcceptOverrideExpression, language, codec, title))
+            {
+                return true;
+            }
+        }
+
+        // Normal filters (all must pass)
+
+        // Language filter
+        if (!config.ExtractAllLanguages)
+        {
+            if (config.SelectedLanguages.Length == 0)
+            {
+                return false;
+            }
+
+            if (!config.SelectedLanguages.Contains(language, StringComparer.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        // Codec/type filter
+        if (!config.ExtractAllCodecTypes)
+        {
+            if (config.SelectedCodecTypes.Length == 0)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(codec)
+                || !config.SelectedCodecTypes.Contains(codec, StringComparer.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        // Regex title filter (reject takes precedence over accept)
+        if (!string.IsNullOrWhiteSpace(config.RejectTitleRegex))
+        {
+            try
+            {
+                if (Regex.IsMatch(title, config.RejectTitleRegex, RegexOptions.IgnoreCase, RegexTimeout))
+                {
+                    return false;
+                }
+            }
+            catch (ArgumentException)
+            {
+                // Invalid regex pattern from user input; ignore filter
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // Regex took too long; ignore filter
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(config.AcceptTitleRegex))
+        {
+            try
+            {
+                if (!Regex.IsMatch(title, config.AcceptTitleRegex, RegexOptions.IgnoreCase, RegexTimeout))
+                {
+                    return false;
+                }
+            }
+            catch (ArgumentException)
+            {
+                // Invalid regex pattern from user input; ignore filter
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // Regex took too long; ignore filter
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Filters a media source's subtitle streams based on configuration.
+    /// Returns null if no subtitle streams match the filter criteria.
+    /// </summary>
+    /// <param name="source">The media source to filter.</param>
+    /// <param name="config">The plugin configuration.</param>
+    /// <returns>The media source with filtered streams, or null if no subtitles match.</returns>
+    public static MediaSourceInfo? FilterMediaSource(MediaSourceInfo source, PluginConfiguration config)
+    {
+        var nonSubStreams = source.MediaStreams
+            .Where(s => s.Type != MediaStreamType.Subtitle)
+            .ToList();
+
+        var filteredSubStreams = source.MediaStreams
+            .Where(s => s.Type == MediaStreamType.Subtitle && ShouldExtractStream(s, config))
+            .ToList();
+
+        if (filteredSubStreams.Count == 0)
+        {
+            return null;
+        }
+
+        source.MediaStreams = [.. nonSubStreams, .. filteredSubStreams];
+        return source;
+    }
+
+    private static bool EvaluateExpression(string expression, string language, string codec, string title)
+    {
+        try
+        {
+            var interpreter = new Interpreter();
+            interpreter.SetVariable("LANGUAGE", language);
+            interpreter.SetVariable("TYPE", codec);
+            interpreter.SetVariable("TITLE", title);
+            return interpreter.Eval<bool>(expression);
+        }
+        catch (Exception)
+        {
+            // Invalid expression from user input; treat as non-matching
+            return false;
+        }
+    }
+}

--- a/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
@@ -9,7 +9,6 @@ using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.MediaEncoding;
-using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Globalization;
 using MediaBrowser.Model.Tasks;
@@ -77,7 +76,6 @@ public class ExtractSubtitlesTask : IScheduledTask
         Guid[] parentIds = [];
         if (libs.Length > 0)
         {
-            // Try to get parent ids from the selected libraries
             parentIds = _libraryManager.GetVirtualFolders()
                 .Where(vf => libs.Contains(vf.Name))
                 .Select(vf => Guid.Parse(vf.ItemId))
@@ -86,7 +84,6 @@ public class ExtractSubtitlesTask : IScheduledTask
 
         if (parentIds.Length > 0)
         {
-            // In case parent ids are found, run the extraction on each found library
             foreach (var parentId in parentIds)
             {
                 startProgress = await RunExtractionWithProgress(progress, parentId, parentIds, startProgress, cancellationToken).ConfigureAwait(false);
@@ -94,7 +91,6 @@ public class ExtractSubtitlesTask : IScheduledTask
         }
         else
         {
-            // Otherwise run it on everything
             await RunExtractionWithProgress(progress, null, [], startProgress, cancellationToken).ConfigureAwait(false);
         }
 
@@ -109,6 +105,8 @@ public class ExtractSubtitlesTask : IScheduledTask
         CancellationToken cancellationToken)
     {
         var libsCount = parentIds.Count > 0 ? parentIds.Count : 1;
+        var config = SubtitleExtractPlugin.Current.Configuration;
+        var workerThreads = Math.Max(1, config.WorkerThreads);
 
         var query = new InternalItemsQuery
         {
@@ -122,20 +120,16 @@ public class ExtractSubtitlesTask : IScheduledTask
             Limit = QueryPageLimit
         };
 
-        var config = SubtitleExtractPlugin.Current.Configuration;
-        // Values are stored separated by comma, and we only need the part before the dash as it is the codec's name.
-        string[] selectedCodecs = config.SelectedCodecs;
-
-        var isAdvancedCodecSelection = config.IsAdvancedMode;
-        var includeTextSubtitles = config.IncludeTextSubtitles;
-        var includeGraphicalSubtitles = config.IncludeGraphicalSubtitles;
-
         if (!parentId.IsNullOrEmpty())
         {
             query.ParentId = parentId.Value;
         }
 
         var numberOfVideos = _libraryManager.GetCount(query);
+        if (numberOfVideos == 0)
+        {
+            return startProgress + (100d / libsCount);
+        }
 
         var startIndex = 0;
         var completedVideos = 0;
@@ -145,46 +139,32 @@ public class ExtractSubtitlesTask : IScheduledTask
             query.StartIndex = startIndex;
             var videos = _libraryManager.GetItemList(query);
 
-            foreach (var video in videos)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                foreach (var mediaSource in video.GetMediaSources(false).Where(source => FilterMediasWithCodec(isAdvancedCodecSelection, includeTextSubtitles, includeGraphicalSubtitles, selectedCodecs, source)))
+            await Parallel.ForEachAsync(
+                videos,
+                new ParallelOptions
                 {
-                    await _encoder.ExtractAllExtractableSubtitles(mediaSource, cancellationToken).ConfigureAwait(false);
-                }
+                    MaxDegreeOfParallelism = workerThreads,
+                    CancellationToken = cancellationToken
+                },
+                async (video, ct) =>
+                {
+                    foreach (var mediaSource in video.GetMediaSources(false))
+                    {
+                        var filtered = SubtitleStreamFilter.FilterMediaSource(mediaSource, config);
+                        if (filtered is not null)
+                        {
+                            await _encoder.ExtractAllExtractableSubtitles(filtered, ct).ConfigureAwait(false);
+                        }
+                    }
 
-                completedVideos++;
-
-                // Report the progress using "startProgress" that allows to track progress across multiple libraries
-                progress.Report(startProgress + (100d * completedVideos / numberOfVideos / libsCount));
-            }
+                    var completed = Interlocked.Increment(ref completedVideos);
+                    progress.Report(startProgress + (100d * completed / numberOfVideos / libsCount));
+                }).ConfigureAwait(false);
 
             startIndex += QueryPageLimit;
         }
 
-        // When done, update the startProgress to the current progress for next libraries
-        startProgress += 100d * completedVideos / numberOfVideos / libsCount;
+        startProgress += 100d / libsCount;
         return startProgress;
-    }
-
-    /// <summary>
-    /// Filters given media depending on codecs to include.
-    /// </summary>
-    /// <param name="isAdvancedMode">Whether to check codec or just subtitle type.</param>
-    /// <param name="includeTextSubtitles">Whether to include text subtitles.</param>
-    /// <param name="includeGraphicalSubtitles">Whether to include graphical subtitles.</param>
-    /// <param name="selectedCodecs">The list of codecs to include.</param>
-    /// <param name="source">the media source.</param>
-    /// <returns>True if media should be handled.</returns>
-    private static bool FilterMediasWithCodec(bool isAdvancedMode, bool includeTextSubtitles, bool includeGraphicalSubtitles, IReadOnlyCollection<string> selectedCodecs, MediaSourceInfo source)
-    {
-        var subtitleStreams = source.MediaStreams.Where(stream => stream.Type == MediaStreamType.Subtitle).ToArray();
-        if (!isAdvancedMode)
-        {
-            return (includeTextSubtitles && subtitleStreams.All(stream => stream.IsTextSubtitleStream)) || (includeGraphicalSubtitles && subtitleStreams.Any(stream => !stream.IsTextSubtitleStream));
-        }
-
-        return subtitleStreams.All(stream => selectedCodecs.Contains(stream.Codec, StringComparer.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
A bit overboard, but comprehensive enough such that I can't see a scenario where filtering by metadata using these filters is ever limiting.

These settings are more or less nice-to-haves since extracting less tracks won't necessarily speed up extraction. My interest is in not dumping a bunch of subtitle tracks I'll never use into my library structure. I do a lot of "external management", so I do wind up "dealing" with this kind of stuff.

I also took the liberty of dumping in a worker thread option since defaulting to a single thread basically collapses the concept. Regardless, apologies in advance for the laziness in wadding it into this commit. My reason for that is for very high bandwidth and or solid state backed libraries, where it is actually possible to be bottlenecked by ffmpeg demuxing and extracting blocks, rather than smoothly running along sequential disk access.

This is all coming from an MKV perspective.

New Settings:
- Language filter: 76 language types with an "extract all" master toggle (on by default)
- Subtitle type filter: 20 codec types with an "extract all" master toggle (on by default)
- Title regex filters: accept and reject pattern textboxes, reject takes precedence
- Override expressions: accept and reject DynamicExpresso-powered C# boolean expressions (disabled by default) that bypass normal filters, with variables LANGUAGE, TYPE, and TITLE
- Worker threads: configurable parallel extraction (default 1, max 32).