### PR TITLE
Set IncludeGraphicalSubtitles default to false

### DIFF
--- a/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Configuration/PluginConfiguration.cs
@@ -80,5 +80,5 @@ public class PluginConfiguration : BasePluginConfiguration
     /// <summary>
     /// Gets or sets a value indicating whether advanced codec selection mode is enabled.
     /// </summary>
-    public bool IncludeGraphicalSubtitles { get; set; } = true;
+    public bool IncludeGraphicalSubtitles { get; set; } = false;
 }


### PR DESCRIPTION
Starting with server v10.11, graphical subtitle extraction in the plugin is enabled by default. This leads to the server's `/config/data/subtitles` directory ballooning in size, with graphic subtitles taking up a multiple of space.

On a sample library of 150 movie files, the extracted subtitle directory takes up
51MB with text-based subtitles only
8.6GB with extraction of image-based subtitles enabled, a 168x increase in size (!)

Graphical subtitles don't benefit from extraction to the same extent as text-based subtitles do as they're burned in on the server side. Without the bottleneck of time-consuming on-the-fly extraction server-side, the biggest upside of extracting subtitles is nullified afaik - so I think defaulting `IncludeGraphicalSubtitles` to false is a much more sane approach for most server admins (with the option to enable it for advanced use cases) imo.

This should resolve the underlying root cause of issues like #54 and #55 (users running out of disk space after updating to 10.11) without server admins having to troubleshoot what's responsible for a server's large config directory.

Thank you @Gorgorot38 for the amazing improvements in #53!