### PR TITLE
doc: Make documentation and plugin short descriptions a bit clearer.

### DIFF
--- a/Jellyfin.Plugin.SubtitleExtract/SubtitleExtractPlugin.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/SubtitleExtractPlugin.cs
@@ -31,7 +31,7 @@ public class SubtitleExtractPlugin : BasePlugin<PluginConfiguration>, IHasWebPag
     public override Guid Id => new("CD893C24-B59E-4060-87B2-184070E1BF68");
 
     /// <inheritdoc />
-    public override string Description => "Extracts embedded subtitles and attachments";
+    public override string Description => "Extracts embedded subtitles and attachments proactively outside of playing media. It allows optional subtitle extraction during library scans, or as a scheduled task";
 
     /// <summary>
     /// Gets the current plugin instance.

--- a/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
+++ b/Jellyfin.Plugin.SubtitleExtract/Tasks/ExtractSubtitlesTask.cs
@@ -55,7 +55,7 @@ public class ExtractSubtitlesTask : IScheduledTask
     public string Name => "Extract Subtitles";
 
     /// <inheritdoc />
-    public string Description => "Extracts embedded subtitles.";
+    public string Description => "Extracts embedded subtitles proactively.";
 
     /// <inheritdoc />
     public string Category => _localization.GetLocalizedString("TasksLibraryCategory");

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## About
 
-Plugin to automatically extract embedded subtitles.
+Plugin to automatically extract embedded subtitles proactively outside of playing media. It allows optional subtitle extraction during library scans, or as a scheduled task.
 
 ## Installation
 

--- a/build.yaml
+++ b/build.yaml
@@ -5,9 +5,9 @@ version: 7
 targetAbi: "10.11.2.0"
 framework: "net9.0"
 owner: "jellyfin"
-overview: "Extracts Subtitles."
+overview: "Extracts subtitles proactively."
 description: >
-  Extracts embedded subtitles.
+  Extracts embedded subtitles proactively.
 
 category: "Subtitles"
 artifacts:


### PR DESCRIPTION
I was a bit confused as to what the plugin actually does, when I looked for a plugin that extracts subtitles during library scan, since the current description 'Extracting subtitles' is something that vanilla jellyfin already does.
I tried make it a little bit clearer.